### PR TITLE
fix(canvas): 用 ctx.effect 直接注册 de_canvas 工具

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -828,11 +828,12 @@ export function installCanvas(ctx, config, resolveCwd, resolveSessionName) {
   const base = '/memory-evolve/api/canvas'
   const disposers = []
 
-  // 工具注册（tools 服务存在时）。
-  ctx.inject(['tools'], (toolCtx) => {
-    const cancel = toolCtx.tools.register(canvasToolDefinition(config, resolveCwd))
-    disposers.push(cancel)
-  })
+  // 工具注册（与 memory/todo 工具同一路径：apply 已声明 inject:['tools']，
+  // ctx.tools 在调用 installCanvas 时已就绪，直接 register 即可。
+  // 原先的 ctx.inject(['tools'], cb) 在 apply 运行期（fiber 已 running）订阅
+  // tools 回调，cordis 不再触发该回调，导致 de_canvas 从未注册——
+  // 表现为画板 Tab/HTTP API 正常，但 de_canvas 不出现在任何会话的工具清单里。
+  ctx.effect(() => ctx.tools.register(canvasToolDefinition(config, resolveCwd)), 'dsh-memory-evolve: de_canvas tool')
 
   // HTTP API（web-only；TUI 上自动待机无副作用）。
   ctx.inject(['webServer'], (webCtx) => {


### PR DESCRIPTION
原注册使用 ctx.inject(['tools'], cb) 在 apply 运行期（fiber 已 running） 订阅 tools 回调，cordis 不再触发该回调，导致 de_canvas 从未注册——
表现为画板 Tab/HTTP API 正常，但 de_canvas 不出现在任何会话的工具
清单里（2026-08-14 用户反馈「其他会话不会用」的根因）。

改为与 memory/todo 工具一致的 ctx.effect(() => ctx.tools.register(...))， apply 已声明 inject:['tools']，ctx.tools 在调用 installCanvas 时已就绪， 直接 register 即可。经 DSH tools.register 的 assertSupportedJsonSchema 实测 de_canvas 的 output.schema/parameters 均零 violation，确认根因在注册时机 而非 schema。