### PR TITLE
fix(bundle): add missing dsh.bundle manifest and cordis.patch.yml

### DIFF
--- a/README-详细说明.md
+++ b/README-详细说明.md
@@ -300,30 +300,28 @@ DSH 会话之间传递消息的轻量子功能，**独立于 COI 调度框架**�
 
 ### 标准安装（DSH 08-06+ profiles 架构，推荐）
 
-插件以包形式安装进 profile（`web` / `tui` / `headless` 等），由 profile 的
-`cordis.patch.yml` 组合。以 web profile 为例：
+插件以包形式安装进 profile（`web` / `tui` / `headless` 等）。包内自带
+`cordis.patch.yml`，`dsh plugin add` 安装后 bundle patch 会自动注册 host 行，
+不需要再往 profile patch 里手动 `insert`（重复 insert 同 id 会导致加载器
+报 duplicate loader entry id）：
 
 ```sh
-# 1. 安装到 profile（本地目录用 link:，也可用 git/registry 包地址）
+# 安装到 profile（本地目录用 link:，也可用 git/registry 包地址）
 dsh plugin --profile web add link:/path/to/dsh-memory-evolve
-
-# 2. 在 profile 的 patch 层注册（编辑 ~/.dsh/profiles/web/cordis.patch.yml）：
 ```
+
+如需修改默认配置（如开启回合内记忆审查），在 profile 的 patch 层做 id 覆盖
+（编辑 `~/.dsh/profiles/web/cordis.patch.yml`）：
 
 ```yaml
-- insert:
-    - id: dsh-memory-evolve
-      name: dsh-memory-evolve
-      config:
-        reviewEnabled: true      # 开启回合内记忆审查（默认关）
-        reviewInterval: 10       # 每 10 个用户回合审查一次
+- id: dsh-memory-evolve
+  config:
+    reviewEnabled: true      # 开启回合内记忆审查（默认关）
+    reviewInterval: 10       # 每 10 个用户回合审查一次
 ```
 
-重启 `dsh web` 即生效。卸载：删除 patch 中的 insert 行 + `dsh plugin --profile web remove dsh-memory-evolve`，一切效果随插件卸载自动清理。
-
-> 注意：client bundle 注册 ID 取自 `package.json` 的 `name`，patch 行的
-> `name` 必须与之完全一致（`dsh-memory-evolve`），不要加 `@dsh-local/`
-> 前缀——那是 08-06 之前旧机制的软链命名空间。
+重启 `dsh web` 即生效。卸载：`dsh plugin --profile web remove dsh-memory-evolve`，
+一切效果随插件卸载自动清理。
 
 ### 旧机制（DSH 08-06 之前，不再推荐）
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,0 +1,10 @@
+# dsh-memory-evolve bundle patch: inserts the host row into the profile's
+# plugin roster. The browser half rides the package's `dsh.client` manifest
+# (the client registry serves lib/client.js), and this row materializes the
+# memory / skills / todos / CLI-dispatch host plugin on boot.
+# Install with `dsh plugin --profile <name> add <path-or-git-url>`; the bundle
+# patch is applied automatically, so do NOT insert this row again in the
+# profile patch (duplicate ids crash the loader).
+- insert:
+    - id: dsh-memory-evolve
+      name: 'dsh-memory-evolve'

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
         "@deepseek-ai/dsh-client-runtime"
       ],
       "platform": "web"
+    },
+    "bundle": {
+      "patch": "./cordis.patch.yml"
     }
   }
 }


### PR DESCRIPTION
## 问题

`dsh-memory-evolve` 以 profile bundle 方式安装时，`package.json` 没有声明 `dsh.bundle`，仓库里也没有 `cordis.patch.yml`。DSH 启动器对 `dsh.profile.bundles` 里的每个包都强制读取该声明，缺失时直接崩溃：

```
Error: dsh: profile bundle "dsh-memory-evolve" declares no dsh.bundle in its package.json
```

复现：`dsh plugin --profile web add link:/path/to/dsh-memory-evolve` 后运行 `dsh web` 即崩（headless 不受影响）。

## 修复

- `package.json`：新增 `dsh.bundle.patch: "./cordis.patch.yml"`（参照 `dsh-wsl-workspace` 等标准 bundle）
- 新增 `cordis.patch.yml`：`insert` host 行 `id: dsh-memory-evolve` / `name: 'dsh-memory-evolve'`；客户端半边仍由 `dsh.client` 清单提供，配置默认值全部来自 `lib/index.js`
- `README-详细说明.md`：标准安装改为「bundle patch 自动注册」，去掉手动 `insert` 步骤（同 id 重复 insert 会让加载器报 duplicate loader entry id），保留 profile patch 的 `id` 覆盖式配置示例

## 验证

- 本地实机：补上两份文件后 `dsh --profile web --dump-default-config` 通过，组合树可见 `dsh-memory-evolve` 层；`dsh web` 正常启动，HTTP 200
- 回滚安全：删除 patch 字段 + patch 文件即可回到原状态
