### PR TITLE
feat(notify): 站内通知存储 live-read + 正文链接可点击

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -15482,6 +15482,34 @@ var SEP_RE = /^[━─—\-_=]{4,}\s*$/;
 function collapseBlank(text) {
   return String(text ?? "").replace(/\r\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
 }
+var NOTIFY_LINK_RE = /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)|(https?:\/\/[^\s<>()"'\]]+)/g;
+function linkify(text) {
+  var s = String(text == null ? "" : text);
+  NOTIFY_LINK_RE.lastIndex = 0;
+  var parts = [];
+  var last = 0;
+  var m;
+  while ((m = NOTIFY_LINK_RE.exec(s)) !== null) {
+    if (m.index > last) parts.push(s.slice(last, m.index));
+    if (m[1] !== void 0) parts.push({ u: m[2], l: m[1] });
+    else parts.push({ u: m[3], l: m[3] });
+    last = NOTIFY_LINK_RE.lastIndex;
+  }
+  if (last < s.length) parts.push(s.slice(last));
+  if (parts.length === 0) return s.replace(/\*\*/g, "");
+  return parts.map(function (p, k) {
+    if (p && typeof p === "object") {
+      return (0, import_jsx_runtime27.jsx)("a", {
+        key: k,
+        href: p.u,
+        target: "_blank",
+        rel: "noreferrer",
+        children: p.l
+      });
+    }
+    return String(p).replace(/\*\*/g, "");
+  });
+}
 function stripSubjectPrefix(s) {
   return String(s ?? "").replace(/^[📮📝👤🕐📄]\s*(主题|简介|发送人|时间|内容)\s*[：:]\s*/, "").trim();
 }
@@ -15829,7 +15857,7 @@ function Bell({ openSession, t: t2 }) {
                         children: displaySubject(item)
                       }
                     ),
-                    preview ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { className: `me-notify-content${item.isLong ? " me-notify-content-clamped" : ""}`, children: preview }) : null,
+                    preview ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { className: `me-notify-content${item.isLong ? " me-notify-content-clamped" : ""}`, children: linkify(preview) }) : null,
                     item.attachments.length > 0 && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(AttachmentList, { item }),
                     /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { className: "me-notify-item-actions", children: [
                       /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("button", { type: "button", className: "me-notify-markread", onClick: () => markReadItem(item.id), children: t2("notify.markRead") }),
@@ -15857,7 +15885,7 @@ function Bell({ openSession, t: t2 }) {
               modalParsed.intro && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { className: "me-notify-mail-intro", children: modalParsed.intro }),
               modalParsed.body && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("pre", { className: "me-notify-modal-content", children: modalParsed.body }),
               modalParsed.leftover && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("pre", { className: "me-notify-modal-content", children: modalParsed.leftover })
-            ] }) : /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("pre", { className: "me-notify-modal-content", children: collapseBlank(modal.content) }),
+            ] }) : /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("pre", { className: "me-notify-modal-content", children: linkify(collapseBlank(modal.content)) }),
             modal.item.attachments.length > 0 && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(AttachmentList, { item: modal.item }),
             /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { className: "me-notify-detail-actions", children: [
               modal.item.sender !== "" && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(

--- a/lib/notify-web.js
+++ b/lib/notify-web.js
@@ -109,6 +109,7 @@ export class NotificationStore {
    * @returns {{ok: boolean, id?: string, message?: string}}
    */
   async add(input) {
+    this.#load()
     const sender = String(input.sender ?? '')
     const semantic = input.semantic === 'direct' ? 'direct' : 'notify'
     const content = String(input.content ?? '')
@@ -147,6 +148,7 @@ export class NotificationStore {
 
   /** 未读数（铃铛数字）。 */
   unreadCount() {
+    this.#load()
     return this.items.filter((i) => i.read !== true).length
   }
 
@@ -158,6 +160,7 @@ export class NotificationStore {
    *   提供，因为需要访问 agents/sessionTitle 服务；缺省回退短 ID）。
    */
   list(type, resolveSenderName) {
+    this.#load()
     const wanted = type === 'all' ? this.items : this.items.filter((i) => i.read !== true)
     return wanted.map((m) => ({
       id: m.id,
@@ -182,6 +185,7 @@ export class NotificationStore {
 
   /** 取单条原文（含长内容文件）。 */
   full(id) {
+    this.#load()
     const m = this.items.find((i) => i.id === id)
     if (!m) return null
     let content = m.content
@@ -193,6 +197,7 @@ export class NotificationStore {
 
   /** 标记已读（批量 ids；返回实际命中数）。 */
   read(ids) {
+    this.#load()
     const set = new Set(Array.isArray(ids) ? ids.map(String) : [])
     let hit = 0
     for (const m of this.items) {
@@ -207,6 +212,7 @@ export class NotificationStore {
 
   /** 全部标记已读。 */
   readAll() {
+    this.#load()
     let hit = 0
     for (const m of this.items) {
       if (m.read !== true) { m.read = true; hit += 1 }
@@ -217,6 +223,7 @@ export class NotificationStore {
 
   /** 删除单条（连带正文文件与附件，不留孤儿）。 */
   remove(id) {
+    this.#load()
     const at = this.items.findIndex((i) => i.id === id)
     if (at < 0) return { ok: false, message: `通知 ${id} 不存在` }
     const m = this.items[at]
@@ -231,6 +238,7 @@ export class NotificationStore {
 
   /** 按 id 取附件（下载端点用）。 */
   attachment(id, index) {
+    this.#load()
     const m = this.items.find((i) => i.id === id)
     const att = m && Array.isArray(m.attachments) ? m.attachments[index] : undefined
     return att && typeof att.file === 'string' ? att : null


### PR DESCRIPTION
## 改动

两个针对「站内通知」的增强：

### 1. NotificationStore live-read（lib/notify-web.js）

- **问题**：NotificationStore 只在构造时读一次 notifications.json 进内存，之后外部进程（如定时任务脚本）写入的文件不会被铃铛读到，直到重启。
- **改法**：给 `unreadCount / list / full / read / readAll / remove / attachment / add` 方法开头各加 `this.#load()`，每次操作实时读文件。这也对齐了文件里已有的「live-read/live-write」注释语义。
- **收益**：配合定时任务直接写 notifications.json，网页铃铛能实时显示，无需重启。

### 2. 正文链接可点击（lib/client.js）

- **问题**：通知正文按纯文本渲染，`[标题](url)` 显示为原始字符、点不动。
- **改法**：新增 `linkify` 函数（正则识别 markdown 链接与裸 URL，转成 `<a target="_blank">`），在列表预览与详情弹窗两处渲染时调用。
- **收益**：站内通知里的新闻/链接可直接点击跳原文。

## 验证

- `node --check lib/client.js` 通过
- 实测：定时脚本写通知后铃铛实时出现、链接点击跳原文

