### PR TITLE
fix(sync): 净化 worker 环境，修复 Windows 下 git 凭据 403

### DIFF
--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -41,7 +41,30 @@ const SCRIPT_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 's
  */
 export function spawnWorker(args) {
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, [SCRIPT_PATH, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
+    // Windows git 凭据修复（2026-08-15 实测）：桌面应用（DeepSeek Harness）
+    // 派生 worker 时环境缺 HOMEDRIVE/HOMEPATH/HOME，git 因此找不到
+    // ~/.gitconfig（gh credential helper 配置），匿名访问私有仓库被
+    // GitHub 403 拒绝（"Write access to repository not granted"）。
+    // 这里按 USERPROFILE 补齐 HOME 三件套——只补缺失项，不覆盖已有值。
+    const env = { ...process.env }
+    if (process.platform === 'win32') {
+      const profile = env.USERPROFILE
+      if (profile) {
+        if (!env.HOME) env.HOME = profile
+        if (!env.HOMEDRIVE && /^([A-Za-z]):/.test(profile)) env.HOMEDRIVE = profile.match(/^([A-Za-z]):/)[1] + ':'
+        if (!env.HOMEPATH) {
+          const m = profile.match(/^[A-Za-z]:(.*)$/)
+          if (m) env.HOMEPATH = m[1]
+        }
+      }
+    }
+    // ── GH_TOKEN 污染修复（2026-08-16 根因确认）：DSH 宿主环境里存在
+    //    GH_TOKEN 环境变量（github_pat_ 开头的 fine-grained PAT，对记忆仓库
+    //    无权限），gh CLI 优先用它认证 → GitHub 403 "Write access not
+    //    granted"。删除后 gh 回退到自身 OAuth 凭据（gh auth login 存储）。
+    delete env.GH_TOKEN
+    delete env.GITHUB_TOKEN
+    const child = spawn(process.execPath, [SCRIPT_PATH, ...args], { stdio: ['ignore', 'pipe', 'pipe'], env })
     let stdout = ''
     let stderr = ''
     child.stdout.on('data', (chunk) => { stdout += String(chunk) })


### PR DESCRIPTION
## 问题

Windows 上 DSH 记忆同步（共享记忆仓库）全局轨推送全部失败：

``
全局轨同步并推送：4 个轨失败（其余成功）：
全局记忆：拉取远端记忆失败（remote: Write access to repository not granted.）
``

## 根因

DSH 宿主进程（原生 dsh web / 桌面应用）的环境里存在 **\GH_TOKEN\** 环境变量——一个 \github_pat_\ 开头的 **fine-grained PAT**。gh CLI（git 的 credential helper）**优先使用 \GH_TOKEN\ 环境变量**认证；当该 token 对记忆仓库没有权限时，GitHub 返回 403 \Write access to repository not granted\，git fetch/push 全部失败。

而普通终端 shell 没有 \GH_TOKEN\，gh 回退到 \gh auth login\ 存的 OAuth token（有权限），所以命令行手动 git 操作一切正常——这导致问题只出现在 DSH 插件 worker 里，极难排查。

复现：设置 \GH_TOKEN\ 为任意无权限的 fine-grained PAT 后运行 \git fetch origin\，即报 \emote: Write access to repository not granted.\ + 403。

## 修复

\spawnWorker\ 启动 sync-worker 子进程前，删除 \GH_TOKEN\ / \GITHUB_TOKEN\ 环境变量，让 gh 回退到自身 OAuth 凭据：

``js
delete env.GH_TOKEN
delete env.GITHUB_TOKEN
``

同时按 \USERPROFILE\ 补齐 \HOME\ / \HOMEDRIVE\ / \HOMEPATH\（Windows 桌面应用派生环境常缺失，git 找不到 \~/.gitconfig\ 凭据配置；只补缺失项，不覆盖已有值）。

## 验证

- 设置 \GH_TOKEN\（无权限 PAT）→ 修复前 4 轨全部 403；修复后 4 轨全部 \已推送\ 成功
- 未设置 \GH_TOKEN\ 的正常环境行为不变（\nv\ 只增删这两个变量，其余原样继承）
- Windows 11 + 原生 dsh web 实测通过

## 影响

- 对没有 \GH_TOKEN\ 的环境：零行为变化（\delete\ 不存在的变量是 no-op）
- 对有 \GH_TOKEN\ 且**确实需要它**的环境：worker 不再用该 token——但 worker 只用 gh 的 git credential helper 访问记忆仓库，删除后回退 OAuth 凭据是预期行为