### PR TITLE
fix(记忆): entries 多轨批量写入单轨容错——单轨异常不再中断循环/丢轨道

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1223,7 +1223,15 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
                   multi.push({ target: t, ok: false, message: '内容不能为空' })
                   continue
                 }
-                const r = await addOne(t, c, item?.feedback, exec)
+                // 单轨容错（issue #18 建议第 3 条）：任何一轨写入抛异常
+                // （如 Windows 上锁文件删除被占用、记忆目录无法创建等）
+                // 只记为该轨失败，不中断循环、不丢弃其余轨道。
+                let r
+                try {
+                  r = await addOne(t, c, item?.feedback, exec)
+                } catch (error) {
+                  r = { ok: false, message: `写入异常：${error?.message ?? String(error)}` }
+                }
                 multi.push({ target: t, ok: r.ok, message: r.message })
               }
               const allOk = multi.every((m) => m.ok)

--- a/tests/entries-batch-fault.test.js
+++ b/tests/entries-batch-fault.test.js
@@ -1,0 +1,83 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { MemoryStore } from '../lib/store.js'
+import { memoryTool } from '../lib/index.js'
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), 'dsh-mem-evolve-test-'))
+}
+
+/** 最小 memory 工具环境（entries 批量只走 daily/project，不触碰 approval/queue/archive）。 */
+function setup() {
+  const dir = tempDir()
+  const store = new MemoryStore(dir)
+  const tool = memoryTool(
+    { get: () => undefined }, // ctx
+    { toolName: 'memory' },   // config
+    store,
+    {},                      // queue（key 轨确认队列，entries 用不到）
+    () => ({}),              // getRuntime
+    {},                      // archive
+  )
+  const agent = { session: { header: { cwd: join(dir, 'proj') } } }
+  return { dir, store, tool, agent }
+}
+
+/** 模拟 DSH 的无损 JSON 安检：往返序列化不丢字段、无 undefined/NaN/Infinity。 */
+function lossless(value) {
+  const s = JSON.stringify(value)
+  assert.ok(!/undefined|NaN|Infinity/.test(s), `value contains non-lossless tokens: ${s}`)
+  assert.deepEqual(JSON.parse(s), value)
+}
+
+test('entries 多轨批量：单轨抛异常时其余轨道照常写入、失败被记录、返回无损', async () => {
+  const { dir, store, tool, agent } = setup()
+  const origAdd = store.add.bind(store)
+  // 让 project 轨写入抛异常（模拟锁文件删除失败等意外）
+  store.add = (target, content, a) => {
+    if (String(content).includes('BOOM')) throw new Error('模拟锁文件删除失败: .memory.lock')
+    return origAdd(target, content, a)
+  }
+  const exec = { agent }
+  // 修复前：循环在 project 轨中断（daily 已写但结果丢失、返回值含 undefined）→ 断言失败；
+  // 修复后：单轨失败被记录、循环继续、两轨结果齐全。
+  const result = await tool.execute(
+    { action: 'add', entries: [
+      { target: 'daily', content: '正常轨写入' },
+      { target: 'project', content: 'BOOM 触发异常' },
+    ] },
+    exec,
+  )
+  assert.equal(result.ok, false)
+  assert.equal(result.multi.length, 2, '两轨结果都必须返回，不能丢轨道')
+  const daily = result.multi.find((m) => m.target === 'daily')
+  const project = result.multi.find((m) => m.target === 'project')
+  assert.equal(daily.ok, true)
+  assert.equal(project.ok, false)
+  assert.match(project.message, /写入异常/, '失败原因必须给 LLM 看到')
+  assert.equal(store.entriesOf('daily').length, 1, '正常轨必须真实落盘')
+  lossless(result)
+  rmSync(dir, { recursive: true, force: true })
+})
+
+test('entries 多轨批量：全部正常时 allOk 为 true 且返回无损', async () => {
+  const { dir, store, tool, agent } = setup()
+  const exec = { agent }
+  const result = await tool.execute(
+    { action: 'add', entries: [
+      { target: 'daily', content: '第一轨' },
+      { target: 'project', content: '第二轨' },
+    ] },
+    exec,
+  )
+  assert.equal(result.ok, true)
+  assert.equal(result.multi.length, 2)
+  assert.ok(result.multi.every((m) => m.ok))
+  assert.equal(store.entriesOf('daily').length, 1)
+  assert.equal(store.entriesOf('project', agent).length, 1)
+  lossless(result)
+  rmSync(dir, { recursive: true, force: true })
+})


### PR DESCRIPTION
## 背景
Issue #18 建议修复第 3 条：多轨 entries 逐轨写入时，单轨失败不应中断/丢弃其余轨道。
先说明现状：#18 的两个主诉（锁文件 trash 删除失败、`not lossless JSON`）在 DSH 0.1.0-rc.7 + 当前 main 上实测均已无法复现——当前代码用 rmSync 删除锁文件，所有返回分支均保证 message 为字符串。

## 本 PR 修复的隐患
即便如此，`lib/index.js` 的 entries 多轨批量循环中，`addOne` 调用没有任何异常保护：任何一轨写入抛异常（如 Windows 上锁文件删除被占用）会中断整个循环，后续轨道被静默丢弃；外层兜底返回对象还可能含 undefined，过不了 DSH 的无损 JSON 校验，LLM 无法得知各轨状态。

## 修改
- 给每轨 `addOne` 包 try/catch：单轨异常只记为该轨失败（`{ok:false, message:"写入异常:..."}`），循环继续，其余轨道照常落盘；message 保证为字符串，返回值始终无损 JSON，LLM 能看到每轨成败。
- 新增回归测试 `tests/entries-batch-fault.test.js`：在无此修复的代码上会失败（复现旧行为：循环中断、结果缺 multi），证明测试有效。

## 验证
- 新增测试：有修复 pass 2/2；无修复 fail 1/1（能抓回旧 bug）
- 全量测试：747 tests / 691 pass / 56 fail——56 个失败均为既有环境问题（darwin 平台测试、git 更新测试等），基线对比失败数一致，与本次改动无关