### PR TITLE
feat(notify): 站内通知存储 live-read + 正文链接可点击（源码级重建产物，承接 #15）

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -15555,6 +15555,25 @@ function previewText(item) {
   }
   return text;
 }
+var NOTIFY_LINK_RE = /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)|(https?:\/\/[^\s<>()"'\]]+)/g;
+function linkify(text) {
+  const s = String(text ?? "");
+  NOTIFY_LINK_RE.lastIndex = 0;
+  const parts = [];
+  let last = 0;
+  let m;
+  while ((m = NOTIFY_LINK_RE.exec(s)) !== null) {
+    if (m.index > last) parts.push(s.slice(last, m.index));
+    if (m[1] !== void 0) parts.push({ u: m[2], l: m[1] });
+    else parts.push({ u: m[3], l: m[3] });
+    last = NOTIFY_LINK_RE.lastIndex;
+  }
+  if (last < s.length) parts.push(s.slice(last));
+  if (parts.length === 0) return s.replace(/\*\*/g, "");
+  return parts.map(
+    (p, k) => p && typeof p === "object" ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("a", { href: p.u, target: "_blank", rel: "noreferrer", children: p.l }, k) : String(p).replace(/\*\*/g, "")
+  );
+}
 function fmtTime3(ts) {
   const d = new Date(ts);
   const pad = (n) => String(n).padStart(2, "0");
@@ -15829,7 +15848,7 @@ function Bell({ openSession, t: t2 }) {
                         children: displaySubject(item)
                       }
                     ),
-                    preview ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { className: `me-notify-content${item.isLong ? " me-notify-content-clamped" : ""}`, children: preview }) : null,
+                    preview ? /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { className: `me-notify-content${item.isLong ? " me-notify-content-clamped" : ""}`, children: linkify(preview) }) : null,
                     item.attachments.length > 0 && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(AttachmentList, { item }),
                     /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { className: "me-notify-item-actions", children: [
                       /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("button", { type: "button", className: "me-notify-markread", onClick: () => markReadItem(item.id), children: t2("notify.markRead") }),
@@ -15857,7 +15876,7 @@ function Bell({ openSession, t: t2 }) {
               modalParsed.intro && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("div", { className: "me-notify-mail-intro", children: modalParsed.intro }),
               modalParsed.body && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("pre", { className: "me-notify-modal-content", children: modalParsed.body }),
               modalParsed.leftover && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("pre", { className: "me-notify-modal-content", children: modalParsed.leftover })
-            ] }) : /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("pre", { className: "me-notify-modal-content", children: collapseBlank(modal.content) }),
+            ] }) : /* @__PURE__ */ (0, import_jsx_runtime27.jsx)("pre", { className: "me-notify-modal-content", children: linkify(collapseBlank(modal.content)) }),
             modal.item.attachments.length > 0 && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(AttachmentList, { item: modal.item }),
             /* @__PURE__ */ (0, import_jsx_runtime27.jsxs)("div", { className: "me-notify-detail-actions", children: [
               modal.item.sender !== "" && /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(

--- a/lib/notify-web.js
+++ b/lib/notify-web.js
@@ -109,6 +109,7 @@ export class NotificationStore {
    * @returns {{ok: boolean, id?: string, message?: string}}
    */
   async add(input) {
+    this.#load()
     const sender = String(input.sender ?? '')
     const semantic = input.semantic === 'direct' ? 'direct' : 'notify'
     const content = String(input.content ?? '')
@@ -147,6 +148,7 @@ export class NotificationStore {
 
   /** 未读数（铃铛数字）。 */
   unreadCount() {
+    this.#load()
     return this.items.filter((i) => i.read !== true).length
   }
 
@@ -158,6 +160,7 @@ export class NotificationStore {
    *   提供，因为需要访问 agents/sessionTitle 服务；缺省回退短 ID）。
    */
   list(type, resolveSenderName) {
+    this.#load()
     const wanted = type === 'all' ? this.items : this.items.filter((i) => i.read !== true)
     return wanted.map((m) => ({
       id: m.id,
@@ -182,6 +185,7 @@ export class NotificationStore {
 
   /** 取单条原文（含长内容文件）。 */
   full(id) {
+    this.#load()
     const m = this.items.find((i) => i.id === id)
     if (!m) return null
     let content = m.content
@@ -193,6 +197,7 @@ export class NotificationStore {
 
   /** 标记已读（批量 ids；返回实际命中数）。 */
   read(ids) {
+    this.#load()
     const set = new Set(Array.isArray(ids) ? ids.map(String) : [])
     let hit = 0
     for (const m of this.items) {
@@ -207,6 +212,7 @@ export class NotificationStore {
 
   /** 全部标记已读。 */
   readAll() {
+    this.#load()
     let hit = 0
     for (const m of this.items) {
       if (m.read !== true) { m.read = true; hit += 1 }
@@ -217,6 +223,7 @@ export class NotificationStore {
 
   /** 删除单条（连带正文文件与附件，不留孤儿）。 */
   remove(id) {
+    this.#load()
     const at = this.items.findIndex((i) => i.id === id)
     if (at < 0) return { ok: false, message: `通知 ${id} 不存在` }
     const m = this.items[at]
@@ -231,6 +238,7 @@ export class NotificationStore {
 
   /** 按 id 取附件（下载端点用）。 */
   attachment(id, index) {
+    this.#load()
     const m = this.items.find((i) => i.id === id)
     const att = m && Array.isArray(m.attachments) ? m.attachments[index] : undefined
     return att && typeof att.file === 'string' ? att : null

--- a/src/client/notification-bell.tsx
+++ b/src/client/notification-bell.tsx
@@ -300,6 +300,50 @@ function previewText(item: NotificationItem): string {
   return text
 }
 
+/* ------------------------------------------------------------------ */
+/* 正文链接化（markdown 链接 + 裸 URL → 可点击 <a>）                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 正文里的链接识别正则（一次匹配两种形态，交替捕获组）：
+ *   1) markdown 链接：[标题](https://...)
+ *   2) 裸 URL：https://...
+ * URL 只接受 http(s) 且排除空白/尖括号/引号/括号字符（防 XSS 属性注入、
+ * 防吞掉相邻标点）；标题允许任意字符（除 ] 与换行）。
+ */
+const NOTIFY_LINK_RE = /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)|(https?:\/\/[^\s<>()"'\]]+)/g
+
+/**
+ * 把通知正文渲染为可点击链接：
+ * - 命中 markdown 链接 / 裸 URL 时返回 React 节点数组（<a target="_blank"
+ *   rel="noreferrer">，href 恒为 http(s)，文本经 React 转义，无 XSS）；
+ * - 未命中任何链接时原样返回字符串（仅移除 markdown 加粗符 **），
+ *   调用方可直接当 children 渲染（字符串/数组 React 都接受）。
+ * 返回类型 string | ReactNode[]：preview 与详情弹窗两处复用。
+ */
+function linkify(text: string | null | undefined): string | React.ReactNode[] {
+  const s = String(text ?? '')
+  NOTIFY_LINK_RE.lastIndex = 0 // 全局正则跨调用复用，必须重置游标
+  const parts: (string | { u: string; l: string })[] = []
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = NOTIFY_LINK_RE.exec(s)) !== null) {
+    if (m.index > last) parts.push(s.slice(last, m.index))
+    if (m[1] !== undefined) parts.push({ u: m[2], l: m[1] }) // markdown 链接：u=URL l=标题
+    else parts.push({ u: m[3], l: m[3] }) // 裸 URL：u 与 l 都是 URL 本身
+    last = NOTIFY_LINK_RE.lastIndex
+  }
+  if (last < s.length) parts.push(s.slice(last))
+  if (parts.length === 0) return s.replace(/\*\*/g, '')
+  return parts.map((p, k) =>
+    p && typeof p === 'object' ? (
+      <a key={k} href={p.u} target="_blank" rel="noreferrer">{p.l}</a>
+    ) : (
+      String(p).replace(/\*\*/g, '')
+    )
+  )
+}
+
 /** 时间显示：当天 HH:mm，跨天 MM-DD HH:mm。 */
 function fmtTime(ts: number): string {
   const d = new Date(ts)
@@ -643,10 +687,10 @@ function Bell({ openSession, t }: NotificationBellOpts): JSX.Element {
                   >
                     {displaySubject(item)}
                   </button>
-                  {/* 内容：已去重主题、折叠空行；长文截断 + 「查看详情」。 */}
+                  {/* 内容：已去重主题、折叠空行；长文截断 + 「查看详情」。正文链接化（linkify）。 */}
                   {preview ? (
                     <div className={`me-notify-content${item.isLong ? ' me-notify-content-clamped' : ''}`}>
-                      {preview}
+                      {linkify(preview)}
                     </div>
                   ) : null}
                   {item.attachments.length > 0 && <AttachmentList item={item} />}
@@ -706,7 +750,7 @@ function Bell({ openSession, t }: NotificationBellOpts): JSX.Element {
                   )}
                 </div>
               ) : (
-                <pre className="me-notify-modal-content">{collapseBlank(modal.content)}</pre>
+                <pre className="me-notify-modal-content">{linkify(collapseBlank(modal.content))}</pre>
               )}
               {modal.item.attachments.length > 0 && <AttachmentList item={modal.item} />}
               <div className="me-notify-detail-actions">


### PR DESCRIPTION
承接 PR #15（simbamo 原稿）的同名改动，修正其"直接手改构建产物 lib/client.js"的问题：按项目范式（PR #12 改源码 + 重建产物一起提交）把 linkify 逻辑落到源码 src/client/notification-bell.tsx 后重新 build，避免下次构建覆盖手改内容导致功能丢失。

## 改动
- lib/notify-web.js：NotificationStore 各方法（add/unreadCount/list/full/read/readAll/remove/attachment）开头加 #load()，每次操作实时重读 notifications.json——外部进程（定时任务脚本）写入的通知，网页铃铛无需重启即可读到（与原稿一致）
- src/client/notification-bell.tsx：新增 linkify（NOTIFY_LINK_RE 识别 markdown 链接与裸 URL，渲染为 <a target="_blank" rel="noreferrer">；仅接受 http(s) URL 且排除引号/尖括号字符，文本经 React 转义，无 XSS）；列表预览与详情弹窗两处渲染接入
- lib/client.js：由 pnpm build（scripts/build.mjs + esbuild）重新生成，与源码同步，功能与原稿等价

## 验证
- node --check lib/client.js 通过
- tests/notify-web.test.js 4/4 通过
- 全量测试 747/747 通过