### PR TITLE
fix(技能/更新): 修复 CRLF 行尾技能解析 + 更新器信任校验诊断增强（issue #17）

### DIFF
--- a/lib/skills.js
+++ b/lib/skills.js
@@ -63,7 +63,11 @@ export function parseFrontmatter(text) {
   if (!match) return undefined
   const fields = {}
   for (const line of match[1].split('\n')) {
-    const field = /^([a-zA-Z0-9_-]+):\s*(.*)$/.exec(line)
+    // Windows/CRLF 兼容（issue #17）：split('\n') 后每行尾部残留 \r，
+    // 而 JS 正则中 . 不匹配 \r、$ 不匹配 \r 前的位置——"name: foo\r"
+    // 整行匹配失败 → fields 缺 name → 返回 undefined → 技能被静默跳过。
+    // 先剥掉行尾 \r 再解析（分隔符正则已支持 \r?\n，这里补行内处理）。
+    const field = /^([a-zA-Z0-9_-]+):\s*(.*)$/.exec(line.replace(/\r+$/, ''))
     if (!field) continue
     const rawValue = field[2].trim()
     const quoted = (rawValue.startsWith('"') && rawValue.endsWith('"'))

--- a/lib/update.js
+++ b/lib/update.js
@@ -730,9 +730,24 @@ export function createUpdateChecker(opts = {}) {
       }
 
       // —— 信任边界：发布提交必须是 origin/main 祖先 ——
+      // 预检对象存在性（issue #17 诊断增强）：本地对象库不完整（浅克隆/
+      // 历史被裁剪/部分克隆）时 merge-base 结果不可信，可能把"本地缺对象"
+      // 误报成"tag 不在历史上"。先 cat-file -e 确认两个提交对象都在本地，
+      // 缺失时给出明确修复指引，而不是笼统误报 untrusted。
+      const shaObj = await runGit(repoDir, ['cat-file', '-e', `${sha}^{commit}`], { run })
+      if (!shaObj.ok) {
+        return { ok: false, code: 'error', error: `本地缺少发布提交 ${sha.slice(0, 12)} 的对象（仓库历史可能被裁剪或为浅克隆）——请先执行 git fetch --unshallow origin 完整拉取历史后重试` }
+      }
+      const mainObj = await runGit(repoDir, ['cat-file', '-e', `${mainRef}^{commit}`], { run })
+      if (!mainObj.ok) {
+        return { ok: false, code: 'error', error: `本地缺少 origin/main 提交对象（仓库历史可能被裁剪或为浅克隆）——请先执行 git fetch --unshallow origin 完整拉取历史后重试` }
+      }
       const trusted = await runGit(repoDir, ['merge-base', '--is-ancestor', sha, mainRef], { run })
       if (!trusted.ok && trusted.code !== 1) {
-        return { ok: false, code: 'error', error: `信任校验执行失败（${trusted.kind}），已中止` }
+        // 执行失败（如 merge-base 对异常仓库报错）：把 git 原始 stderr 首行
+        // 带进错误信息，让用户/排查者能定位真实原因，不再只给笼统文案。
+        const detail = String(trusted.stderr ?? '').trim().split('\n')[0] ?? ''
+        return { ok: false, code: 'error', error: `信任校验执行失败（${trusted.kind}）${detail !== '' ? `：${detail}` : ''}，已中止` }
       }
       if (trusted.code === 1) {
         return { ok: false, code: 'untrusted', error: `${expectedTag} 不在 origin/main 的历史上，已拒绝更新` }

--- a/tests/skills.test.js
+++ b/tests/skills.test.js
@@ -65,6 +65,16 @@ test('parseFrontmatter accepts canonical skills and rejects malformed ones', () 
   assert.equal(quoted.description, '带 空格 的描述')
 })
 
+test('parseFrontmatter handles Windows CRLF line endings (issue #17)', () => {
+  // Windows 下 SKILL.md 是 CRLF 行尾：修复前行内字段正则不匹配 "name: foo\r"
+  // 整行 → frontmatter 解析 undefined → 技能被静默跳过（回归测试）。
+  const crlf = '---\r\nname: demo-skill\r\ndescription: 演示技能\r\n---\r\n# 正文\r\n'
+  const parsed = parseFrontmatter(crlf)
+  assert.equal(parsed.name, 'demo-skill')
+  assert.equal(parsed.description, '演示技能')
+  assert.ok(parsed.body.includes('# 正文'))
+})
+
 test('listSkills and readSkill', () => {
   const dir = tempDir()
   mkdirSync(join(dir, 'alpha'), { recursive: true })

--- a/tests/update.test.js
+++ b/tests/update.test.js
@@ -319,6 +319,30 @@ test('信任校验：tag 不在 origin/main 历史 → untrusted', async () => {
   assert.equal(outcome.code, 'untrusted')
 })
 
+test('信任校验：本地对象缺失（浅克隆/裁剪）时明确提示，不误报 untrusted', async () => {
+  const { consumer } = setupRepo()
+  // 注入：仅 cat-file 命令模拟失败（对象缺失），其余走真实 git。
+  const checker = createUpdateChecker({
+    repoDir: consumer,
+    now: advancingClock(),
+    run: async (cmd, args, opts) => {
+      if (cmd === 'git' && args[0] === 'cat-file') {
+        const err = new Error('missing object')
+        err.status = 128
+        err.stderr = 'fatal: git cat-file: could not get object info'
+        throw err
+      }
+      return realRun(cmd, args, opts)
+    },
+  })
+  const outcome = await checker.update('v1.1.0')
+  assert.equal(outcome.ok, false)
+  assert.equal(outcome.code, 'error')
+  // 关键：必须是"对象缺失"提示（含修复指引），而不是 untrusted 误报。
+  assert.match(outcome.error, /缺少发布提交|缺少 origin\/main 提交对象/)
+  assert.doesNotMatch(outcome.error, /不在 origin\/main 的历史上/)
+})
+
 test('checkout 失败：不乐观写状态，返回 error', async () => {
   const { consumer } = setupRepo()
   // 注入：仅 checkout 命令模拟失败（抛非零退出）。


### PR DESCRIPTION
修复 issue #17 的两个问题：

## 1. CRLF 行尾技能解析（确认 bug）
lib/skills.js parseFrontmatter 行内字段正则 . 不匹配 \r、$ 不匹配 \r 前位置——Windows CRLF 的 "name: foo\r" 整行匹配失败 → frontmatter 解析 undefined → skill_manage list 静默跳过该技能。修复：循环内先剥行尾 \r。回归测试 tests/skills.test.js 新增 CRLF 用例。

## 2. 更新器信任校验诊断增强
- 校验前 cat-file -e 预检 tag 提交与 origin/main 提交对象是否在本地：浅克隆/历史裁剪时 merge-base 结果不可信，可能把"本地缺对象"误报成"tag 不在历史上"——现在缺失时给出明确修复指引（git fetch --unshallow origin）
- merge-base 执行失败时把 git 原始 stderr 首行带进错误信息，便于定位

注：更新器核心逻辑核查结论——parseTagRefs 正确解引用 annotated tag、merge-base 方向正确，当前远端数据下实测校验通过（v26081701 的 commit c5e2221 确实是 main 祖先），issue 报告者的 untrusted 无法在当前数据下复现，最可能与本地 git 对象状态有关，本次增强即为该场景提供明确诊断。

## 验证
全量测试 749/749 通过（747 存量 + 2 新增回归测试）
