### PR TITLE
fix(review): 监听 agent/turn-stopping 并修复 trigger 字段崩溃（issue #24）

### DIFF
--- a/lib/review.js
+++ b/lib/review.js
@@ -5,7 +5,7 @@
  * subagent, no digest, no transcript reconstruction). The plugin only
  * provides the pace-maker and the write paths:
  *
- *   pace    `agent/settled` counts completed message-triggered turns per
+ *   pace    `agent/turn-stopping` counts completed message-triggered turns per
  *           session; when the count reaches `reviewInterval` the review is
  *           DUE. The counter is never auto-reset — only the model's
  *           `memory_review_status complete` call resets it, so a missed or
@@ -42,32 +42,58 @@ export function reviewTurnCounter(ctx, getRuntime) {
   /** agentId → number of completed user turns since the last review. */
   const perSession = new Map()
 
-  const onSettled = (agent, turn, reason) => {
-    if (agent.session.header.origin === 'subagent') return
-    if (!getRuntime().reviewEnabled) return
-    if (reason.kind !== 'completed') return
-    // Count only message-triggered turns (retries and injections are not user turns).
-    const events = agent.session.events
-    let messageTurn = false
-    for (let index = events.length - 1; index >= 0; index -= 1) {
-      const event = events[index]
-      if (event?.type === 'turn/start' && event.data.turn === turn) {
-        messageTurn = event.data.trigger.kind === 'message'
-        break
+  // 修复（2026-08-22，issue #24）：DSH 核心不发 `agent/settled`，回合
+  // 正常结束时只发 `agent/turn-stopping`（packages/core/agent-loop/src/
+  // agent.ts，payload={agent, turn, signal}）。原监听 `agent/settled`
+  // 永不触发 → 轮次计数恒 0 → review 永不 due → 全局记忆轨永远无法
+  // 产生。`agent/turn-stopping` 只在回合正常结束时触发（error/abort/
+  // blocked 在 turn-stopping 之前 throw，到不了这里），天然过滤非正常
+  // 回合，故不再需要 reason.kind==='completed' 判断（payload 也没有
+  // reason 参数）。
+  const onSettled = (payload) => {
+    try {
+      const agent = payload?.agent ?? payload
+      if (!agent?.session) return
+      if (agent.session.header.origin === 'subagent') return
+      if (!getRuntime().reviewEnabled) return
+      // Count only message-triggered turns (retries and injections are not user turns).
+      // ⚠ 修复（issue #24 根因 3）：DSH 核心的 turn/start 会话事件 data
+      // 只有 `{ turn }`（见 dsh-agent-loop `session.append('turn/start',
+      // { turn })`），没有 `trigger` 字段——旧代码 `event.data.trigger.kind`
+      // 必然抛 TypeError: Cannot read properties of undefined (reading
+      // 'kind')，经 turn-stopping serial dispatch 冒泡导致整个回合被判
+      // 失败（GUI 显示「本轮运行失败 … UNKNOWN」）。改为可选链 + 兜底：
+      // trigger 缺失时按 message 计数——turn-stopping 仅在
+      // inbox.nextStep.length === 0 时发出，next-step 注入回合已被排除，
+      // 到达这里的都是用户消息回合；DSH 未来若补上 trigger 字段则自动
+      // 恢复正常判定。
+      const events = agent.session.events
+      let messageTurn = false
+      for (let index = events.length - 1; index >= 0; index -= 1) {
+        const event = events[index]
+        if (event?.type === 'turn/start') {
+          const triggerKind = event.data?.trigger?.kind
+          messageTurn = triggerKind === undefined || triggerKind === 'message'
+          break
+        }
       }
+      if (!messageTurn) return
+      const state = perSession.get(agent.id) ?? { turns: 0 }
+      state.turns += 1
+      // Never reset here: due stays sticky until the model completes the review
+      // via `memory_review_status complete`, so a missed turn cannot silently
+      // drop the review.
+      perSession.set(agent.id, state)
+    } catch (error) {
+      // 事件回调抛异常会带崩回合（与 lib/prompts.js 同款防护）：审查
+      // 计数只是节奏器，绝不能让插件异常污染回合结果。
+      console.error('[memory-evolve review] turn-stopping 处理失败（已隔离，不影响回合）：', error)
     }
-    if (!messageTurn) return
-    const state = perSession.get(agent.id) ?? { turns: 0 }
-    state.turns += 1
-    // Never reset here: due stays sticky until the model completes the review
-    // via `memory_review_status complete`, so a missed turn cannot silently
-    // drop the review.
-    perSession.set(agent.id, state)
   }
 
   // 显式挂到 ctx 生命周期（P2-7）：ctx.on 返回的 disposer 交给 ctx.effect
   // 管理，插件卸载/热重载时自动移除监听器，避免重复注册导致重复计数
-  ctx.effect(() => ctx.on('agent/settled', onSettled))
+  ctx.effect(() => ctx.on('agent/turn-stopping', onSettled))
 
   return {
     turnsOf: (agent) => perSession.get(agent?.id)?.turns ?? 0,


### PR DESCRIPTION
根因 1：lib/review.js 监听不存在的 agent/settled，导致审查计数器永不
触发、review 永不 due、全局记忆轨（MEMORY.md）永远无法产生。DSH 核心
回合正常结束时只发 agent/turn-stopping（payload={agent, turn, signal}）， error/abort/blocked 路径在 turn-stopping 之前 throw，天然过滤非正常回合， 故无需 reason.kind==='completed' 判断。

根因 3：turn/start 会话事件 data 只有 { turn }，无 trigger 字段，旧代码 event.data.trigger.kind 必抛 TypeError: Cannot read properties of undefined (reading 'kind')，经 turn-stopping serial dispatch 冒泡导致回合被判失败 （GUI 显示「本轮运行失败 … UNKNOWN」）。改为可选链 + 无 trigger 时按
message 计数兜底（turn-stopping 仅在 inbox.nextStep.length===0 时发出， next-step 注入回合已被排除）。回调整体加 try/catch，与 prompts.js 同款 防护，审查计数异常绝不污染回合结果。