### PR TITLE
fix(review): sync review tools with the runtime toggle

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1481,13 +1481,41 @@ export function apply(ctx, rawConfig = {}) {
   // (the settled listener returns early unless reviewEnabled).
   const counter = reviewTurnCounter(ctx, getRuntime)
   const updateRuntime = (patch) => {
-    for (const [key, value] of Object.entries(patch)) {
-      validateRuntimePatch(key, value)
-      runtime[key] = value
-      state[key] = value
-    }
-    saveState(stateFile, state)
+    const entries = Object.entries(patch)
+    for (const [key, value] of entries) validateRuntimePatch(key, value)
+    const nextState = { ...state, ...patch }
+    const nextRuntime = { ...runtime, ...patch }
+    saveState(stateFile, nextState)
+    Object.assign(state, nextState)
+    Object.assign(runtime, nextRuntime)
     return { ...runtime }
+  }
+
+  // 3. In-turn review tools are one runtime-controlled capability. Register
+  // and dispose the pair together so the snapshot never advertises a review
+  // workflow with only half of its tools available.
+  let reviewToolsDispose = null
+  const reviewCtrl = {
+    sync(desired = runtime.reviewEnabled === true) {
+      const enabled = desired === true
+      if (enabled && reviewToolsDispose === null) {
+        reviewToolsDispose = ctx.effect(() => {
+          let suggestDispose = null
+          try {
+            suggestDispose = ctx.tools.register(suggestToolDefinition(config, queue))
+            const statusDispose = ctx.tools.register(reviewStatusTool(getRuntime, counter))
+            return () => { try { statusDispose() } finally { suggestDispose() } }
+          } catch (error) {
+            suggestDispose?.()
+            throw error
+          }
+        }, 'dsh-memory-evolve: review tools')
+      } else if (!enabled && reviewToolsDispose !== null) {
+        const dispose = reviewToolsDispose
+        reviewToolsDispose = null
+        dispose()
+      }
+    },
   }
 
   // 2d. Local document search (search_local_docs): default OFF — the tool is
@@ -1496,7 +1524,26 @@ export function apply(ctx, rawConfig = {}) {
   // updateRuntime 联动：Web 设置面板 / slash 命令切换后即时注册或注销。
   const searchDocsCtrl = createSearchDocsController(ctx, config, getRuntime)
   const applyRuntimePatch = (patch) => {
-    const next = updateRuntime(patch)
+    // Stage the tool transition before committing the settings patch. A tool
+    // registration failure leaves every runtime/persisted key untouched; a
+    // persistence failure restores the previous tool surface.
+    const previousReviewEnabled = runtime.reviewEnabled === true
+    const desiredReviewEnabled = Object.hasOwn(patch, 'reviewEnabled')
+      ? patch.reviewEnabled
+      : previousReviewEnabled
+    if (Object.hasOwn(patch, 'reviewEnabled')) validateRuntimePatch('reviewEnabled', patch.reviewEnabled)
+    let next
+    try {
+      reviewCtrl.sync(desiredReviewEnabled)
+      next = updateRuntime(patch)
+    } catch (error) {
+      try {
+        reviewCtrl.sync(previousReviewEnabled)
+      } catch (rollbackError) {
+        throw new AggregateError([error, rollbackError], 'dsh-memory-evolve: 运行时设置失败且审查工具回滚不完整')
+      }
+      throw error
+    }
     notifyCtrl.sync() // 渠道通知随 notifyEnabled 即时安装/卸载（先于 COI——COI 依赖其 sendChannelNotify 回调）
     channelSendCtrl.sync() // 渠道直发随 channelSendEnabled 即时安装/卸载（独立开关，与 notify 互不影响）
     sessionImageCtrl.sync() // 本会话图片查询随 sessionImageQueryEnabled 即时安装/卸载（独立开关）
@@ -1542,16 +1589,9 @@ export function apply(ctx, rawConfig = {}) {
   //     directly; model-authored ones go through the suggestion queue).
   ctx.effect(() => ctx.tools.register(todoToolDefinition(config, todoStore)), 'dsh-memory-evolve: todo tool')
 
-  // 3. In-turn review (opt-in): suggest tool + turn counter + status tool.
-  // Machinery is installed whenever the plugin loads (config reviewEnabled OR
-  // the runtime state), but the counter consults the live runtime — the
-  // settings panel can flip it without a reload. The review itself runs
-  // inside the main LLM's turn (prompt-driven, see renderSnapshot).
-  const reviewWanted = config.reviewEnabled || runtime.reviewEnabled
-  if (reviewWanted) {
-    ctx.effect(() => ctx.tools.register(suggestToolDefinition(config, queue)), 'dsh-memory-evolve: suggest tool')
-    ctx.effect(() => ctx.tools.register(reviewStatusTool(getRuntime, counter)), 'dsh-memory-evolve: review status tool')
-  }
+  // 3. In-turn review (opt-in): the live runtime value is the sole authority
+  // for both the snapshot instructions and the paired tool surface.
+  reviewCtrl.sync()
 
   // 3b. 模型配置模块（de_models 工具 + 「模型设置」Tab 数据面）：**独立
   //     子模块**，与其他模块同款独立开关 modelsEnabled（默认关）。开启时

--- a/tests/review-tool-lifecycle.test.js
+++ b/tests/review-tool-lifecycle.test.js
@@ -1,0 +1,253 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { apply } from '../lib/index.js'
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), 'dsh-memory-review-tools-test-'))
+}
+
+function once(fn) {
+  let active = true
+  return () => {
+    if (!active) return
+    active = false
+    return fn?.()
+  }
+}
+
+function fakeCtx({ web = false } = {}) {
+  const state = {
+    tools: [],
+    contexts: [],
+    commands: [],
+    routes: [],
+    listeners: {},
+    effects: [],
+    registrationAttempts: new Map(),
+    disposalCalls: new Map(),
+    failReviewStatusRegistration: false,
+  }
+  const services = {
+    tools: {
+      register(def) {
+        state.registrationAttempts.set(def.name, (state.registrationAttempts.get(def.name) ?? 0) + 1)
+        if (def.name === 'memory_review_status' && state.failReviewStatusRegistration) {
+          throw new Error('injected review-status registration failure')
+        }
+        state.tools.push(def)
+        return once(() => {
+          state.disposalCalls.set(def.name, (state.disposalCalls.get(def.name) ?? 0) + 1)
+          const index = state.tools.indexOf(def)
+          if (index >= 0) state.tools.splice(index, 1)
+        })
+      },
+      get: () => undefined,
+    },
+    systemPrompt: {
+      context(def) {
+        state.contexts.push(def)
+        return once(() => {
+          const index = state.contexts.indexOf(def)
+          if (index >= 0) state.contexts.splice(index, 1)
+        })
+      },
+    },
+    commands: {
+      register(def) {
+        state.commands.push(def)
+        return once(() => {
+          const index = state.commands.indexOf(def)
+          if (index >= 0) state.commands.splice(index, 1)
+        })
+      },
+    },
+  }
+  if (web) {
+    services.webServer = {
+      register(route) {
+        state.routes.push(route)
+        return once(() => {
+          const index = state.routes.indexOf(route)
+          if (index >= 0) state.routes.splice(index, 1)
+        })
+      },
+    }
+  }
+
+  const ctx = {
+    state,
+    tools: services.tools,
+    systemPrompt: services.systemPrompt,
+    commands: services.commands,
+    webServer: services.webServer,
+    on(name, listener) {
+      ;(state.listeners[name] ??= []).push(listener)
+      return once(() => {
+        const index = state.listeners[name].indexOf(listener)
+        if (index >= 0) state.listeners[name].splice(index, 1)
+      })
+    },
+    inject(deps, callback) {
+      if (!deps.every((dep) => services[dep] !== undefined)) return { dispose: () => {} }
+      const dispose = callback(ctx)
+      return { dispose: once(dispose) }
+    },
+    effect(fn) {
+      const dispose = once(fn())
+      state.effects.push(dispose)
+      return dispose
+    },
+    get: (key) => services[key],
+    logger: { warn: () => {}, info: () => {}, error: () => {} },
+  }
+  return ctx
+}
+
+function toolCount(ctx, name) {
+  return ctx.state.tools.filter((tool) => tool.name === name).length
+}
+
+function snapshotText(ctx, cwd) {
+  const snapshot = ctx.state.contexts.find((context) => context.name === 'memory:snapshot')
+  assert.ok(snapshot, 'memory snapshot registered')
+  return snapshot.text({ agent: { id: 'main', session: { header: { cwd } } } })
+}
+
+function assertReviewSurface(ctx, cwd, enabled) {
+  const expectedCount = enabled ? 1 : 0
+  assert.equal(toolCount(ctx, 'memory_suggest'), expectedCount)
+  assert.equal(toolCount(ctx, 'memory_review_status'), expectedCount)
+  const snapshot = snapshotText(ctx, cwd)
+  assert.equal(snapshot.includes('memory_suggest'), enabled)
+  assert.equal(snapshot.includes('memory_review_status'), enabled)
+}
+
+function disposeCtx(ctx) {
+  for (let index = ctx.state.effects.length - 1; index >= 0; index -= 1) {
+    try { ctx.state.effects[index]() } catch { /* best-effort test cleanup */ }
+  }
+}
+
+async function startApi(ctx) {
+  const route = ctx.state.routes.find((candidate) => candidate.path === '/memory-evolve')
+  assert.ok(route, 'memory-evolve API registered')
+  const server = createServer((req, res) => route.handler(req, res))
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const base = `http://127.0.0.1:${server.address().port}`
+  const request = async (method, body) => {
+    const response = await fetch(`${base}/memory-evolve/api/config`, {
+      method,
+      headers: body === undefined ? undefined : { 'content-type': 'application/json' },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    })
+    return { status: response.status, body: await response.json() }
+  }
+  return {
+    config: () => request('GET'),
+    patch: (patch) => request('POST', { patch }),
+    close: () => new Promise((resolve) => server.close(resolve)),
+  }
+}
+
+test('runtime review toggle keeps the paired tools and snapshot atomic', async () => {
+  const dir = tempDir()
+  const stateFile = join(dir, 'plugin-state.json')
+  const initialState = { reviewEnabled: false, searchDocsEnabled: false }
+  writeFileSync(stateFile, `${JSON.stringify(initialState, null, 2)}\n`)
+  const ctx = fakeCtx({ web: true })
+  apply(ctx, { memoryDir: dir, reviewEnabled: false })
+  const api = await startApi(ctx)
+  try {
+    assertReviewSurface(ctx, dir, false)
+
+    // The real panel posts all config keys together. If the second review-tool
+    // registration fails, no unrelated key may be committed without its
+    // controller sync running.
+    ctx.state.failReviewStatusRegistration = true
+    const failed = await api.patch({ reviewEnabled: true, searchDocsEnabled: true })
+    assert.equal(failed.status, 400)
+    assert.match(failed.body.error, /injected review-status registration failure/)
+    assertReviewSurface(ctx, dir, false)
+    assert.equal(toolCount(ctx, 'memory_evolve_search_local_files'), 0)
+    assert.equal(ctx.state.disposalCalls.get('memory_suggest'), 1, 'partial registration rolled back')
+    const afterFailure = await api.config()
+    assert.equal(afterFailure.body.config.reviewEnabled, false)
+    assert.equal(afterFailure.body.config.searchDocsEnabled, false)
+    assert.deepEqual(JSON.parse(readFileSync(stateFile, 'utf8')), initialState)
+
+    // A persistence failure happens after successful tool staging. It must
+    // restore the old pair and leave the same mixed patch wholly uncommitted.
+    ctx.state.failReviewStatusRegistration = false
+    const blockedTemp = `${stateFile}.tmp.${process.pid}`
+    mkdirSync(blockedTemp)
+    let persistFailed
+    try {
+      persistFailed = await api.patch({ reviewEnabled: true, searchDocsEnabled: true })
+    } finally {
+      rmSync(blockedTemp, { recursive: true, force: true })
+    }
+    assert.equal(persistFailed.status, 400)
+    assertReviewSurface(ctx, dir, false)
+    assert.equal(toolCount(ctx, 'memory_evolve_search_local_files'), 0)
+    const afterPersistFailure = await api.config()
+    assert.equal(afterPersistFailure.body.config.reviewEnabled, false)
+    assert.equal(afterPersistFailure.body.config.searchDocsEnabled, false)
+    assert.deepEqual(JSON.parse(readFileSync(stateFile, 'utf8')), initialState)
+
+    const enabled = await api.patch({ reviewEnabled: true })
+    assert.equal(enabled.status, 200)
+    assert.equal(enabled.body.config.reviewEnabled, true)
+    assertReviewSurface(ctx, dir, true)
+
+    const attemptsAfterEnable = new Map(ctx.state.registrationAttempts)
+    const repeatedEnable = await api.patch({ reviewEnabled: true })
+    assert.equal(repeatedEnable.status, 200)
+    assert.deepEqual(ctx.state.registrationAttempts, attemptsAfterEnable, 'same-state enable is a registration no-op')
+    assertReviewSurface(ctx, dir, true)
+
+    const disabled = await api.patch({ reviewEnabled: false })
+    assert.equal(disabled.status, 200)
+    assertReviewSurface(ctx, dir, false)
+    const disposalsAfterDisable = new Map(ctx.state.disposalCalls)
+
+    const repeatedDisable = await api.patch({ reviewEnabled: false })
+    assert.equal(repeatedDisable.status, 200)
+    assert.deepEqual(ctx.state.disposalCalls, disposalsAfterDisable, 'same-state disable is a disposal no-op')
+    assertReviewSurface(ctx, dir, false)
+
+    const suggestAttemptsBeforeReenable = ctx.state.registrationAttempts.get('memory_suggest')
+    const statusAttemptsBeforeReenable = ctx.state.registrationAttempts.get('memory_review_status')
+    const reenabled = await api.patch({ reviewEnabled: true })
+    assert.equal(reenabled.status, 200)
+    assertReviewSurface(ctx, dir, true)
+    assert.equal(ctx.state.registrationAttempts.get('memory_suggest'), suggestAttemptsBeforeReenable + 1)
+    assert.equal(ctx.state.registrationAttempts.get('memory_review_status'), statusAttemptsBeforeReenable + 1)
+  } finally {
+    await api.close()
+    disposeCtx(ctx)
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('persisted reviewEnabled is the initial source of truth over static config', () => {
+  const cases = [
+    { config: false, persisted: true, expected: true },
+    { config: true, persisted: false, expected: false },
+  ]
+  for (const item of cases) {
+    const dir = tempDir()
+    const ctx = fakeCtx()
+    try {
+      writeFileSync(join(dir, 'plugin-state.json'), `${JSON.stringify({ reviewEnabled: item.persisted }, null, 2)}\n`)
+      apply(ctx, { memoryDir: dir, reviewEnabled: item.config })
+      assertReviewSurface(ctx, dir, item.expected)
+    } finally {
+      disposeCtx(ctx)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})


### PR DESCRIPTION
## Problem

Issue #24 documents a settings-path mismatch: when the plugin starts with `reviewEnabled: false`, turning review on later updates the live snapshot but the one-time registration never adds `memory_suggest` or `memory_review_status`. The model is then instructed to review without having the tools needed to do it.

## Cause

`reviewWanted` was evaluated only during plugin startup and combined static configuration with persisted runtime state. It was not synchronized by `applyRuntimePatch`.

## Fix

- make the live `runtime.reviewEnabled` value the single authority for both snapshot instructions and the review-tool surface;
- register and dispose `memory_suggest` plus `memory_review_status` as one paired capability;
- stage the tool transition before committing a settings save, so a registration failure leaves the entire multi-key patch untouched;
- restore the previous tool surface if state persistence fails;
- keep repeated enable/disable requests idempotent and support disable/re-enable without reloading the plugin.

This addresses root cause 2 of #24 only. It intentionally does not touch the turn-counter event work covered by #25, so the two changes remain independent.

## Verification

- `node --test tests/review-tool-lifecycle.test.js tests/plugin.test.js tests/api.test.js tests/config-freshness.test.js` — 48 passed
- lifecycle failure-path tests cover mixed-key registration failure and forced persistence failure
- syntax and diff checks passed

Addresses root cause 2 of #24.