### PR TITLE
feat(i18n): full English UI support (host tools + web views), zh stays default

### DIFF
--- a/lib/advisor/index.js
+++ b/lib/advisor/index.js
@@ -26,6 +26,10 @@ import { randomUUID } from 'node:crypto'
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { appendFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { translate, getLocale, MISC2_DICT } from '../i18n.js'
+
+/** Translate through MISC2_DICT in the active host locale. */
+const adt = (key, params) => translate(MISC2_DICT, key, params, getLocale())
 import { AdvisorRuntime } from './runtime.js'
 import { AdvisorConversation } from './conversation.js'
 import { ScopeStore } from './scopes.js'
@@ -730,12 +734,12 @@ function registerAdvisorCommands(commands, ctrl, observer, getSession) {
   }
   const handler = (invocation) => {
     const sessionId = invocation.agent?.session?.id
-    if (sessionId === undefined) return { kind: 'error', text: '无法识别当前会话' }
+    if (sessionId === undefined) return { kind: 'error', text: adt('adv.noSession') }
     switch (parse(invocation.rawInput).kind) {
       case 'toggle': {
         // 2026-08-13 总闸：全局关闭时 toggle 不再能悄悄打开本会话评审
         if (ctrl.configSnapshot().advisorEnabled !== true) {
-          return { kind: 'error', text: 'Advisor 全局开关未开启：请先在 设置 → 配置 打开「会话评审（Advisor）」，再为会话单独开关' }
+          return { kind: 'error', text: adt('adv.globalOff', { verb: 'toggle' }) }
         }
         const before = ctrl.status(sessionId)
         return ctrl.setSessionOverride(sessionId, !before.effectiveEnabled).effectiveEnabled
@@ -745,7 +749,7 @@ function registerAdvisorCommands(commands, ctrl, observer, getSession) {
       case 'on': {
         // 2026-08-13 总闸：全局关闭时拒绝会话级开启，给出明确的开启路径
         if (ctrl.configSnapshot().advisorEnabled !== true) {
-          return { kind: 'error', text: 'Advisor 全局开关未开启：请先在 设置 → 配置 打开「会话评审（Advisor）」，再为会话单独开启' }
+          return { kind: 'error', text: adt('adv.globalOff', { verb: 'enable' }) }
         }
         const before = ctrl.status(sessionId)
         if (before.effectiveEnabled && before.runtimeStatus !== 'quota_exhausted' && before.runtimeStatus !== 'halted') {
@@ -773,16 +777,16 @@ function registerAdvisorCommands(commands, ctrl, observer, getSession) {
         // Q3：新建评审会话——清空评审员持续上下文 + 去重记忆（epoch 自增）
         const result = ctrl.resetConversation(sessionId)
         if (result === null) {
-          return { kind: 'error', text: '无法重置：本会话 Advisor 未启用或运行时不可用' }
+          return { kind: 'error', text: adt('adv.cannotReset') }
         }
-        return { kind: 'success', text: `已新建评审会话（#${result.epoch}）——评审员上下文已清空，可在第一条指令中告知背景信息。` }
+        return { kind: 'success', text: adt('adv.resetDone', { epoch: result.epoch }) }
       }
       case 'tell': {
         const text = parse(invocation.rawInput).text
-        if (text === '') return { kind: 'error', text: '指令不能为空：/advisor tell <指令内容>' }
+        if (text === '') return { kind: 'error', text: adt('adv.tellEmpty') }
         try {
           ctrl.tell(sessionId, text)
-          return { kind: 'success', text: `指令已入队：${text}` }
+          return { kind: 'success', text: adt('adv.tellQueued', { text }) }
         } catch (error) {
           return { kind: 'error', text: error instanceof Error ? error.message : String(error) }
         }

--- a/lib/advisor/runtime.js
+++ b/lib/advisor/runtime.js
@@ -43,6 +43,10 @@
  */
 
 import { CONTENT_FREE_PHRASES, createEmissionGuard, normalizeNote } from './guard.js'
+import { translate, getLocale, MISC2_DICT } from '../i18n.js'
+
+/** Translate through MISC2_DICT in the active host locale. */
+const art = (key, params) => translate(MISC2_DICT, key, params, getLocale())
 import { QA_SYSTEM_PROMPT_SUFFIX } from './prompt.js'
 import { AdvisorConversation } from './conversation.js'
 // 角色包裹标记（2026-08-13 用户反馈：评审员必须分清谁对谁说话）
@@ -560,7 +564,7 @@ export class AdvisorRuntime {
           this.emitStatus('quota_exhausted')
           this.emitFinished(reviewId, meta, startedAt, instructionTexts, 'failed', null, {
             code: 'QUOTA_EXCEEDED',
-            message: `评审调用被限流：${failure.message}`,
+            message: art('adv.rateLimited', { detail: failure.message }),
             retryable: true,
           })
           return
@@ -594,7 +598,7 @@ export class AdvisorRuntime {
     }
     this.emitFinished(reviewId, meta, startedAt, instructionTexts, 'failed', null, {
       code: 'TRANSIENT_FAILURE',
-      message: '评审调用多次失败，本轮丢弃',
+      message: art('adv.droppedAfterRetries'),
       retryable: true,
     })
   }
@@ -606,7 +610,7 @@ export class AdvisorRuntime {
     this.activeReservation = undefined
     this.emitFinished(reviewId, meta, startedAt, instructionTexts, 'cancelled', null, {
       code: 'CANCELLED',
-      message: '评审被中止（会话销毁/停用）',
+      message: art('adv.aborted'),
       retryable: false,
     })
   }
@@ -694,7 +698,7 @@ export class AdvisorRuntime {
       this.conversation.appendAssistant(`[${result.note.severity}] ${result.note.text}`)
     }
     this.emitFinished(reviewId, meta, startedAt, instructionTexts, outcome, result.note,
-      outcome === 'dropped' ? { code: 'DELIVERY_FAILED', message: '投递失败（缺 agent 或 steer 抛错）', retryable: false } : null,
+      outcome === 'dropped' ? { code: 'DELIVERY_FAILED', message: art('adv.deliveryFailed'), retryable: false } : null,
       deliveryKind)
   }
 
@@ -737,7 +741,7 @@ export class AdvisorRuntime {
     const answer = streamed.text.trim()
     if (answer === '') {
       this.logger.debug('advisor: question reply empty — transient failure (retry once)')
-      return { kind: 'failure', failure: { message: 'advisor 问答返回空回答', code: 'EMPTY_ANSWER' } }
+      return { kind: 'failure', failure: { message: art('adv.emptyAnswer'), code: 'EMPTY_ANSWER' } }
     }
     const bounded = answer.length > ADVISOR_ANSWER_MAX_CHARS
       ? `${answer.slice(0, ADVISOR_ANSWER_MAX_CHARS - 1)}…`

--- a/lib/advisor/store.js
+++ b/lib/advisor/store.js
@@ -26,6 +26,10 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs'
+import { translate, getLocale, MISC2_DICT } from '../i18n.js'
+
+/** Translate through MISC2_DICT in the active host locale. */
+const ast_ = (key, params) => translate(MISC2_DICT, key, params, getLocale())
 
 /** 每会话 live 事件环容量。 */
 export const RING_CAPACITY = 200
@@ -141,7 +145,7 @@ export class ReviewStore {
         type: 'storage-error',
         ts: this.now(),
         code: 'RECORD_TOO_LARGE',
-        message: `评审记录超限（${bytes} 字节），已跳过落盘`,
+        message: ast_('adv.recordTooLarge', { bytes }),
         reviewId: event.reviewId,
         sessionId: event.sessionId,
       })
@@ -158,7 +162,7 @@ export class ReviewStore {
         type: 'storage-error',
         ts: this.now(),
         code: 'APPEND_FAILED',
-        message: `评审记录落盘失败：${error?.message ?? String(error)}`,
+        message: ast_('adv.recordWriteFailed', { detail: error?.message ?? String(error) }),
         reviewId: event.reviewId,
         sessionId: event.sessionId,
       })
@@ -200,7 +204,7 @@ export class ReviewStore {
             type: 'storage-error',
             ts: this.now(),
             code: 'CORRUPT_LINE',
-            message: `records.jsonl 第 ${i + 1} 行损坏，已跳过：${error?.message ?? String(error)}`,
+            message: ast_('adv.lineCorrupt', { line: i + 1, detail: error?.message ?? String(error) }),
           })
         }
       }

--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -12,6 +12,10 @@
  */
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { translate, getLocale, MISC2_DICT } from './i18n.js'
+
+/** Translate through MISC2_DICT in the active host locale. */
+const alt = (key, params) => translate(MISC2_DICT, key, params, getLocale())
 
 /** 别名长度上限（10 个字符，中文友好）。 */
 export const ALIAS_MAX_LEN = 10
@@ -59,7 +63,7 @@ export class AliasStore {
    */
   set(sessionId, name) {
     const sid = String(sessionId ?? '').trim()
-    if (!sid) return { ok: false, message: '会话 id 不能为空' }
+    if (!sid) return { ok: false, message: alt('alias.needsSid') }
     const text = String(name ?? '').trim()
     if (text === '') {
       // 清空 = 移除别名
@@ -67,14 +71,14 @@ export class AliasStore {
         delete this.aliases[sid]
         this.#save()
       }
-      return { ok: true, message: '已清除会话别名' }
+      return { ok: true, message: alt('alias.cleared') }
     }
     if (text.length > ALIAS_MAX_LEN) {
-      return { ok: false, message: `别名最多 ${ALIAS_MAX_LEN} 个字（当前 ${text.length} 字）` }
+      return { ok: false, message: alt('alias.tooLong', { max: ALIAS_MAX_LEN, len: text.length }) }
     }
     this.aliases[sid] = text
     this.#save()
-    return { ok: true, message: `会话别名已设为「${text}」` }
+    return { ok: true, message: alt('alias.set', { alias: text }) }
   }
 
   /** 清除别名。 */

--- a/lib/api.js
+++ b/lib/api.js
@@ -31,6 +31,10 @@
 
 import { URL } from 'node:url'
 import { join } from 'node:path'
+import { translate, getLocale, MISC2_DICT } from './i18n.js'
+
+/** Translate through MISC2_DICT in the active host locale. */
+const apit = (key, params) => translate(MISC2_DICT, key, params, getLocale())
 import { approveSuggestions, archiveSuggestions, promoteArchived, rejectSuggestions } from './review.js'
 import { RUNTIME_KEYS, gitBranch, gitBranchList } from './index.js'
 import { AliasStore } from './aliases.js'
@@ -474,7 +478,7 @@ export function installApi(ctx, deps) {
         // 全局轨开关：POST { sessionId, track, on }——track ∈ memory/user/daily/todo
         const body = await readBody(req)
         const track = String(body?.track ?? '')
-        const outcome = deps.syncOps ? deps.syncOps.setGlobalTrack(track, body?.on === true) : { kind: 'error', text: '同步模块未装配' }
+        const outcome = deps.syncOps ? deps.syncOps.setGlobalTrack(track, body?.on === true) : { kind: 'error', text: apit('api.syncNotAssembled') }
         sendJson(res, 200, { ok: outcome.kind === 'success', text: outcome.text ?? '' })
         return
       }
@@ -662,7 +666,7 @@ export function installApi(ctx, deps) {
         if (!outcome.ok) {
           throw new Error(`已写入归档（现有 ${appended.total} 条）但主轨删除失败：${outcome.message}——归档里多出的那条可在归档页手动清理`)
         }
-        sendJson(res, 200, { ok: true, message: `已归档（${target}：归档文件现有 ${appended.total} 条；${outcome.message}）` })
+        sendJson(res, 200, { ok: true, message: apit('api.archivedOk', { target, count: appended.total, detail: outcome.message }) })
         return
       }
       if (req.method === 'GET' && path === '/memory-evolve/api/todo') {

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -31,6 +31,10 @@ import {
 import { spawn as spawnProcess } from 'node:child_process'
 import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import { basename, dirname, extname, join, resolve } from 'node:path'
+import { translate, getLocale, MISC2_DICT } from './i18n.js'
+
+/** Translate through MISC2_DICT in the active host locale. */
+const ct2 = (key, params) => translate(MISC2_DICT, key, params, getLocale())
 import { homedir } from 'node:os'
 
 // ---------------------------------------------------------------------------
@@ -833,7 +837,7 @@ export function canvasToolDefinition(config, resolveCwd) {
  */
 function renderCanvasResult(value) {
   if (!value || value.ok === false) {
-    return [{ type: 'text', text: `画板操作失败：${value?.error ?? '未知错误'}` }]
+    return [{ type: 'text', text: ct2('canvas.failed', { detail: value?.error ?? ct2('canvas.unknownError') }) }]
   }
   const lines = []
   if (value.total !== undefined && Array.isArray(value.nodes)) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -4725,7 +4725,7 @@ var DICT = {
     "scope.global": "global"
   }
 };
-var LANG = "zh";
+var LANG = typeof navigator !== "undefined" && navigator.language?.toLowerCase().startsWith("en") ? "en" : "zh";
 function t(key) {
   return DICT[LANG][key] ?? DICT.en[key] ?? key;
 }
@@ -6821,23 +6821,47 @@ function useAdvisorSessionStore(sessionId) {
 // src/client/advisor/AdvisorPanel.tsx
 var import_jsx_runtime16 = require("react/jsx-runtime");
 var CAPSULE_POS_KEY = "dsh-memory-evolve:advisor-capsule-pos";
+var isEn = () => typeof navigator !== "undefined" && navigator.language?.toLowerCase().startsWith("en");
 var STATUS_META2 = {
-  disabled: { icon: "\u2716", label: "\u5DF2\u505C\u7528", cls: "advisor-status-disabled" },
-  idle: { icon: "\u25CF", label: "\u7A7A\u95F2", cls: "advisor-status-idle" },
-  reviewing: { icon: "\u25D0", label: "\u8BC4\u5BA1\u4E2D", cls: "advisor-status-reviewing" },
-  quota_exhausted: { icon: "\u23F8", label: "\u5DF2\u6682\u505C", cls: "advisor-status-paused" },
-  halted: { icon: "\u26A0", label: "\u5DF2\u7EC8\u6B62", cls: "advisor-status-halted" }
+  get disabled() {
+    return { icon: "\u2716", label: isEn() ? "Disabled" : "\u5DF2\u505C\u7528", cls: "advisor-status-disabled" };
+  },
+  get idle() {
+    return { icon: "\u25CF", label: isEn() ? "Idle" : "\u7A7A\u95F2", cls: "advisor-status-idle" };
+  },
+  get reviewing() {
+    return { icon: "\u25D0", label: isEn() ? "Reviewing" : "\u8BC4\u5BA1\u4E2D", cls: "advisor-status-reviewing" };
+  },
+  get quota_exhausted() {
+    return { icon: "\u23F8", label: isEn() ? "Paused" : "\u5DF2\u6682\u505C", cls: "advisor-status-paused" };
+  },
+  get halted() {
+    return { icon: "\u26A0", label: isEn() ? "Halted" : "\u5DF2\u7EC8\u6B62", cls: "advisor-status-halted" };
+  }
 };
 var SEVERITY_META = {
   // Q1：info 最低等级（默认仅记录不注入，面板照常展示）
-  info: { label: "info \xB7 \u8BB0\u5F55", cls: "advisor-severity-info" },
-  nit: { label: "nit \xB7 \u5EFA\u8BAE", cls: "advisor-severity-nit" },
-  concern: { label: "concern \xB7 \u5173\u6CE8", cls: "advisor-severity-concern" },
-  blocker: { label: "blocker \xB7 \u963B\u65AD", cls: "advisor-severity-blocker" },
+  info: { get label() {
+    return isEn() ? "info \xB7 note" : "info \xB7 \u8BB0\u5F55";
+  }, cls: "advisor-severity-info" },
+  nit: { get label() {
+    return isEn() ? "nit \xB7 suggestion" : "nit \xB7 \u5EFA\u8BAE";
+  }, cls: "advisor-severity-nit" },
+  concern: { get label() {
+    return isEn() ? "concern \xB7 watch" : "concern \xB7 \u5173\u6CE8";
+  }, cls: "advisor-severity-concern" },
+  blocker: { get label() {
+    return isEn() ? "blocker \xB7 blocking" : "blocker \xB7 \u963B\u65AD";
+  }, cls: "advisor-severity-blocker" },
   // Q4：问答回复（用户提问的直接回答，非评审建议）
-  answer: { label: "\u56DE\u7B54", cls: "advisor-severity-answer" }
+  answer: { get label() {
+    return isEn() ? "answer" : "\u56DE\u7B54";
+  }, cls: "advisor-severity-answer" }
 };
-var OUTCOME_LABEL = {
+function outcomeLabel(outcome) {
+  return isEn() ? OUTCOME_EN[outcome] : OUTCOME_ZH[outcome];
+}
+var OUTCOME_ZH = {
   delivered: "\u5DF2\u9001\u8FBE",
   // Q1：info 级默认仅记录（事件照发、面板可见，会话流不受打扰）
   recorded: "\u5DF2\u8BB0\u5F55",
@@ -6848,6 +6872,16 @@ var OUTCOME_LABEL = {
   dropped: "\u5DF2\u4E22\u5F03",
   failed: "\u8BC4\u5BA1\u5931\u8D25",
   cancelled: "\u5DF2\u53D6\u6D88"
+};
+var OUTCOME_EN = {
+  delivered: "Delivered",
+  recorded: "Recorded",
+  answered: "Answered",
+  suppressed: "Suppressed",
+  "no-note": "No note",
+  dropped: "Dropped",
+  failed: "Review failed",
+  cancelled: "Cancelled"
 };
 function pad22(value) {
   return value < 10 ? `0${value}` : String(value);
@@ -7474,7 +7508,7 @@ function ReviewCard(props) {
           terminal !== null && /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { children: formatElapsed(terminal.elapsedMs) }),
           terminal?.delivery === "steer" && /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { className: "advisor-delivery", children: "\u5DF2\u9001\u8FBE \u2713" }),
           terminal?.delivery === "inject" && /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { className: "advisor-delivery", children: "\u5DF2\u6CE8\u5165 \u2713" }),
-          terminal !== null && terminal.delivery === null && /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { children: OUTCOME_LABEL[terminal.outcome] })
+          terminal !== null && terminal.delivery === null && /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("span", { children: outcomeLabel(terminal.outcome) })
         ] }),
         identity !== null && /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { className: "advisor-record-owner", title: identity, children: identity }),
         (terminal?.instructions.length ?? 0) > 0 && /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { className: "advisor-consumed-instructions", children: [
@@ -7514,7 +7548,7 @@ function ReviewCard(props) {
         ] }) : note !== null ? /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { className: "advisor-note", children: [
           terminal?.outcome === "suppressed" && /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { className: "advisor-note-meta", children: "\u5DF2\u6291\u5236\uFF1A\u6B64\u6761\u5EFA\u8BAE\u88AB\u95F8\u95E8\u62E6\u622A\uFF08\u53BB\u91CD / \u7A7A\u6CDB\u6291\u5236 / \u6BCF\u8F6E\u4E00\u6761\uFF09\uFF0C\u672A\u6CE8\u5165\u4E3B\u4F1A\u8BDD" }),
           note.text
-        ] }) : /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { className: "advisor-outcome-empty", children: OUTCOME_LABEL[terminal.outcome] }),
+        ] }) : /* @__PURE__ */ (0, import_jsx_runtime16.jsx)("div", { className: "advisor-outcome-empty", children: outcomeLabel(terminal.outcome) }),
         terminal?.error !== null && terminal?.error !== void 0 && /* @__PURE__ */ (0, import_jsx_runtime16.jsxs)("div", { className: "advisor-card-error", children: [
           terminal.error.code,
           "\uFF1A",

--- a/lib/client.js
+++ b/lib/client.js
@@ -38,10 +38,10 @@ var import_react = require("react");
 var import_jsx_runtime = require("react/jsx-runtime");
 function todoTargetLabel(t2, target) {
   const track = target.slice(5);
-  if (track === "life") return `\u5F85\u529E\xB7${t2("todo.track.life")}`;
-  if (track === "work") return `\u5F85\u529E\xB7${t2("todo.track.work")}`;
-  if (track === "project") return `\u5F85\u529E\xB7${t2("todo.track.project")}`;
-  if (track === "daily") return `\u5F85\u529E\xB7${t2("todo.track.daily")}`;
+  if (track === "life") return `${isEn() ? "Todo" : "\u5F85\u529E"}\xB7${t2("todo.track.life")}`;
+  if (track === "work") return `${isEn() ? "Todo" : "\u5F85\u529E"}\xB7${t2("todo.track.work")}`;
+  if (track === "project") return `${isEn() ? "Todo" : "\u5F85\u529E"}\xB7${t2("todo.track.project")}`;
+  if (track === "daily") return `${isEn() ? "Todo" : "\u5F85\u529E"}\xB7${t2("todo.track.daily")}`;
   return target;
 }
 function suggestTargetLabel(t2, target) {
@@ -71,14 +71,15 @@ async function api(path, init) {
   return res.json();
 }
 function summarizeReport(report) {
-  const head = report.lines?.join("\uFF1B") ?? `\u5DF2\u5904\u7406 ${report.removed ?? 0} \u6761`;
-  return `${head}\uFF08\u5269\u4F59 ${report.remaining} \u6761\uFF09`;
+  const head = report.lines?.join(isEn() ? "; " : "\uFF1B") ?? (isEn() ? `${report.removed ?? 0} handled` : `\u5DF2\u5904\u7406 ${report.removed ?? 0} \u6761`);
+  return isEn() ? `${head} (${report.remaining} remaining)` : `${head}\uFF08\u5269\u4F59 ${report.remaining} \u6761\uFF09`;
 }
 function formatTime(iso) {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
   return date.toLocaleString();
 }
+var isEn = () => typeof navigator !== "undefined" && navigator.language?.toLowerCase().startsWith("en");
 function MemoryQueueView(props) {
   const { t: t2, feature, onChanged } = props;
   const [entries, setEntries] = (0, import_react.useState)(null);
@@ -2902,7 +2903,7 @@ function statusLabel(t2, status) {
 }
 function dayLabel(day) {
   const [, month, date] = day.split("-");
-  return `${Number(month)}\u6708${Number(date)}\u65E5`;
+  return typeof navigator !== "undefined" && navigator.language?.toLowerCase().startsWith("en") ? `${Number(month)}/${Number(date)}` : `${Number(month)}\u6708${Number(date)}\u65E5`;
 }
 function TodoView(props) {
   const { t: t2, sessionId } = props;
@@ -6821,45 +6822,45 @@ function useAdvisorSessionStore(sessionId) {
 // src/client/advisor/AdvisorPanel.tsx
 var import_jsx_runtime16 = require("react/jsx-runtime");
 var CAPSULE_POS_KEY = "dsh-memory-evolve:advisor-capsule-pos";
-var isEn = () => typeof navigator !== "undefined" && navigator.language?.toLowerCase().startsWith("en");
+var isEn2 = () => typeof navigator !== "undefined" && navigator.language?.toLowerCase().startsWith("en");
 var STATUS_META2 = {
   get disabled() {
-    return { icon: "\u2716", label: isEn() ? "Disabled" : "\u5DF2\u505C\u7528", cls: "advisor-status-disabled" };
+    return { icon: "\u2716", label: isEn2() ? "Disabled" : "\u5DF2\u505C\u7528", cls: "advisor-status-disabled" };
   },
   get idle() {
-    return { icon: "\u25CF", label: isEn() ? "Idle" : "\u7A7A\u95F2", cls: "advisor-status-idle" };
+    return { icon: "\u25CF", label: isEn2() ? "Idle" : "\u7A7A\u95F2", cls: "advisor-status-idle" };
   },
   get reviewing() {
-    return { icon: "\u25D0", label: isEn() ? "Reviewing" : "\u8BC4\u5BA1\u4E2D", cls: "advisor-status-reviewing" };
+    return { icon: "\u25D0", label: isEn2() ? "Reviewing" : "\u8BC4\u5BA1\u4E2D", cls: "advisor-status-reviewing" };
   },
   get quota_exhausted() {
-    return { icon: "\u23F8", label: isEn() ? "Paused" : "\u5DF2\u6682\u505C", cls: "advisor-status-paused" };
+    return { icon: "\u23F8", label: isEn2() ? "Paused" : "\u5DF2\u6682\u505C", cls: "advisor-status-paused" };
   },
   get halted() {
-    return { icon: "\u26A0", label: isEn() ? "Halted" : "\u5DF2\u7EC8\u6B62", cls: "advisor-status-halted" };
+    return { icon: "\u26A0", label: isEn2() ? "Halted" : "\u5DF2\u7EC8\u6B62", cls: "advisor-status-halted" };
   }
 };
 var SEVERITY_META = {
   // Q1：info 最低等级（默认仅记录不注入，面板照常展示）
   info: { get label() {
-    return isEn() ? "info \xB7 note" : "info \xB7 \u8BB0\u5F55";
+    return isEn2() ? "info \xB7 note" : "info \xB7 \u8BB0\u5F55";
   }, cls: "advisor-severity-info" },
   nit: { get label() {
-    return isEn() ? "nit \xB7 suggestion" : "nit \xB7 \u5EFA\u8BAE";
+    return isEn2() ? "nit \xB7 suggestion" : "nit \xB7 \u5EFA\u8BAE";
   }, cls: "advisor-severity-nit" },
   concern: { get label() {
-    return isEn() ? "concern \xB7 watch" : "concern \xB7 \u5173\u6CE8";
+    return isEn2() ? "concern \xB7 watch" : "concern \xB7 \u5173\u6CE8";
   }, cls: "advisor-severity-concern" },
   blocker: { get label() {
-    return isEn() ? "blocker \xB7 blocking" : "blocker \xB7 \u963B\u65AD";
+    return isEn2() ? "blocker \xB7 blocking" : "blocker \xB7 \u963B\u65AD";
   }, cls: "advisor-severity-blocker" },
   // Q4：问答回复（用户提问的直接回答，非评审建议）
   answer: { get label() {
-    return isEn() ? "answer" : "\u56DE\u7B54";
+    return isEn2() ? "answer" : "\u56DE\u7B54";
   }, cls: "advisor-severity-answer" }
 };
 function outcomeLabel(outcome) {
-  return isEn() ? OUTCOME_EN[outcome] : OUTCOME_ZH[outcome];
+  return isEn2() ? OUTCOME_EN[outcome] : OUTCOME_ZH[outcome];
 }
 var OUTCOME_ZH = {
   delivered: "\u5DF2\u9001\u8FBE",
@@ -7844,7 +7845,7 @@ async function fetchJson3(path, init) {
 }
 function errText2(err) {
   const text = err instanceof Error ? err.message : String(err);
-  return text !== void 0 && text.trim() !== "" ? text : "\u64CD\u4F5C\u5931\u8D25\uFF08\u65E0\u9519\u8BEF\u8BE6\u60C5\uFF09";
+  return text !== void 0 && text.trim() !== "" ? text : isEn3() ? "Operation failed (no error detail)" : "\u64CD\u4F5C\u5931\u8D25\uFF08\u65E0\u9519\u8BEF\u8BE6\u60C5\uFF09";
 }
 function fmtTime2(ts) {
   return new Date(ts).toLocaleString("zh-CN", { year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
@@ -7953,6 +7954,7 @@ function WsCoordSettings({ t: t2 }) {
     error !== null && /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("div", { className: "bb-error", children: error })
   ] });
 }
+var isEn3 = () => typeof navigator !== "undefined" && navigator.language?.toLowerCase().startsWith("en");
 function BroadcastView(props) {
   const { t: t2, sessionId } = props;
   const [view, setView] = (0, import_react16.useState)("messages");
@@ -8105,7 +8107,7 @@ function BroadcastView(props) {
     try {
       const res = await fetchJson3(`/rooms/${encodeURIComponent(room.id)}/dissolve`, { method: "POST" });
       if (res.ok !== true) {
-        setNotice({ kind: "error", text: res.message ?? "\u64CD\u4F5C\u5931\u8D25" });
+        setNotice({ kind: "error", text: res.message ?? (isEn3() ? "Operation failed" : "\u64CD\u4F5C\u5931\u8D25") });
         return;
       }
       setNotice({ kind: "ok", text: t2("broadcast.room.dissolved") });
@@ -8122,13 +8124,13 @@ function BroadcastView(props) {
     });
   };
   const renderMsgCard = (m, expandId, setExpandId) => {
-    const from = m.sender === "system" ? "\u7CFB\u7EDF" : displayName(m.sender, aliases);
+    const from = m.sender === "system" ? isEn3() ? "System" : "\u7CFB\u7EDF" : displayName(m.sender, aliases);
     const to = m.recipients.map((r) => recipientLabel(r, roomMap, aliases)).join(", ");
     const unread = m.readBy.length === 0;
     const isOpen = expandId === m.id;
     return /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { className: "bb-card", children: [
       /* @__PURE__ */ (0, import_jsx_runtime17.jsxs)("div", { className: "bb-row", children: [
-        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { className: "bb-strong", children: m.subject || "\uFF08\u65E0\u4E3B\u9898\uFF09" }),
+        /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { className: "bb-strong", children: m.subject || (isEn3() ? "(no subject)" : "\uFF08\u65E0\u4E3B\u9898\uFF09") }),
         /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { className: `bb-badge${unread ? " bb-badge-unread" : " bb-badge-read"}`, children: unread ? t2("broadcast.msg.unread") : t2("broadcast.msg.read") }),
         m.hasBody && /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { className: "bb-badge bb-badge-long", children: t2("broadcast.messages.long") }),
         /* @__PURE__ */ (0, import_jsx_runtime17.jsx)("span", { className: "bb-grow" }),
@@ -10003,7 +10005,9 @@ async function api6(path, init) {
   return res.json();
 }
 function clamp(text, max = 60) {
-  if (text === null) return "\uFF08\u65E0\uFF09";
+  if (text === null) {
+    return typeof navigator !== "undefined" && navigator.language?.toLowerCase().startsWith("en") ? "(none)" : "\uFF08\u65E0\uFF09";
+  }
   const flat = text.replace(/\s+/g, " ");
   return flat.length > max ? `${flat.slice(0, max)}\u2026` : flat;
 }
@@ -15511,13 +15515,13 @@ function writeDock(dock) {
   } catch {
   }
 }
-var MAIL_FIELD_RE = /^(📮|📝|👤|🕐|📄)\s*(主题|简介|发送人|时间|内容)\s*[：:]?\s*(.*)$/;
+var MAIL_FIELD_RE = /^(📮|📝|👤|🕐|📄)\s*(主题|简介|发送人|时间|内容|Subject|Intro|Sender|Time|Content)\s*[：:]?\s*(.*)$/;
 var SEP_RE = /^[━─—\-_=]{4,}\s*$/;
 function collapseBlank(text) {
   return String(text ?? "").replace(/\r\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
 }
 function stripSubjectPrefix(s) {
-  return String(s ?? "").replace(/^[📮📝👤🕐📄]\s*(主题|简介|发送人|时间|内容)\s*[：:]\s*/, "").trim();
+  return String(s ?? "").replace(/^[📮📝👤🕐📄]\s*(主题|简介|发送人|时间|内容|Subject|Intro|Sender|Time|Content)\s*[：:]\s*/, "").trim();
 }
 function parseNotifyContent(raw) {
   const lines = String(raw ?? "").replace(/\r\n/g, "\n").split("\n");
@@ -15546,11 +15550,11 @@ function parseNotifyContent(raw) {
       result.mail = true;
       const key = m[2];
       const val = (m[3] ?? "").trim();
-      if (key === "\u4E3B\u9898") result.subject = val;
-      else if (key === "\u7B80\u4ECB") result.intro = val;
-      else if (key === "\u53D1\u9001\u4EBA") result.sender = val;
-      else if (key === "\u65F6\u95F4") result.time = val;
-      else if (key === "\u5185\u5BB9") {
+      if (key === "\u4E3B\u9898" || key === "Subject") result.subject = val;
+      else if (key === "\u7B80\u4ECB" || key === "Intro") result.intro = val;
+      else if (key === "\u53D1\u9001\u4EBA" || key === "Sender") result.sender = val;
+      else if (key === "\u65F6\u95F4" || key === "Time") result.time = val;
+      else if (key === "\u5185\u5BB9" || key === "Content") {
         inBody = true;
         if (val) bodyLines.push(val);
       }

--- a/lib/coi/adapters.js
+++ b/lib/coi/adapters.js
@@ -29,6 +29,10 @@
  */
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { translate, getLocale, COI2_DICT } from '../i18n.js'
+
+/** Translate through COI2_DICT in the active host locale. */
+const cat2 = (key, params) => translate(COI2_DICT, key, params, getLocale())
 
 /** 内置四家 AI CLI 适配器（开箱即用）。guide 为简明使用指南。 */
 export const BUILTIN_ADAPTERS = {
@@ -329,8 +333,8 @@ export class AdapterStore {
    */
   setEnabled(id, enabled) {
     const adapter = this.byId.get(id)
-    if (!adapter) return { ok: false, message: `未知适配器 "${id}"` }
-    if (typeof enabled !== 'boolean') return { ok: false, message: 'enabled 必须是布尔值' }
+    if (!adapter) return { ok: false, message: cat2('coi2.adapterUnknown', { id }) }
+    if (typeof enabled !== 'boolean') return { ok: false, message: cat2('coi2.enabledMustBeBool') }
     if (id in BUILTIN_ADAPTERS) {
       // 内置：写 custom 覆盖（保留原定义，仅改 enabled）
       this.custom[id] = { ...BUILTIN_ADAPTERS[id], ...(this.custom[id] ?? {}), id, enabled }
@@ -340,7 +344,7 @@ export class AdapterStore {
       this.#save()
     }
     this.#rebuildIndex()
-    return { ok: true, message: `${adapter.name} 已${enabled ? '启用' : '禁用'}`, adapter: this.byId.get(id) }
+    return { ok: true, message: cat2('coi2.adapterToggled', { name: adapter.name, state: enabled ? cat2('coi2.stateOn') : cat2('coi2.stateOff') }), adapter: this.byId.get(id) }
   }
 }
 

--- a/lib/coi/api.js
+++ b/lib/coi/api.js
@@ -27,6 +27,10 @@ import { URL } from 'node:url'
 import { spawn } from 'node:child_process'
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { translate, getLocale, COI2_DICT } from '../i18n.js'
+
+/** Translate through COI2_DICT in the active host locale. */
+const cap2 = (key, params) => translate(COI2_DICT, key, params, getLocale())
 
 /** Read the JSON request body (capped). */
 async function readBody(req, maxBytes = 256 * 1024) {
@@ -77,16 +81,16 @@ export function installCoiApi(ctx, svc) {
         if (adapter.skillName && typeof body.skillContent === 'string' && body.skillContent.trim() !== '') {
           const file = join(svc.config.skillDir ?? '', adapter.skillName, 'SKILL.md')
           if (existsSync(file)) {
-            skillMessage = `技能 ${adapter.skillName} 已存在，内容未改动（可在适配器页「技能」按钮编辑）`
+            skillMessage = cap2('coi2.skillExistsUnchanged', { skill: adapter.skillName })
           } else {
             try {
               const { normalizeSkillText } = await import('./skills-sync.js')
               const text = normalizeSkillText(body.skillContent, adapter.skillName, adapter.name)
               mkdirSync(join(svc.config.skillDir ?? '', adapter.skillName), { recursive: true })
               writeFileSync(file, text)
-              skillMessage = `技能 ${adapter.skillName} 已自动创建（AI 可见，技能管理 Tab 可禁用）`
+              skillMessage = cap2('coi2.skillAutoCreated', { skill: adapter.skillName })
             } catch (error) {
-              skillMessage = `技能创建失败：${error.message}`
+              skillMessage = cap2('coi2.skillCreateFailed', { detail: error.message })
             }
           }
         }
@@ -94,7 +98,7 @@ export function installCoiApi(ctx, svc) {
       }
       if (req.method === 'DELETE' && segments.length === 5 && segments[2] === 'coi' && segments[3] === 'adapters') {
         const ok = svc.adapters.remove(segments[4])
-        return sendJson(res, 200, ok ? { ok: true } : { ok: false, message: '内置适配器不可删除' })
+        return sendJson(res, 200, ok ? { ok: true } : { ok: false, message: cap2('coi2.builtinUndeletable') })
       }
       if (req.method === 'POST' && segments.length === 6 && segments[2] === 'coi' && segments[3] === 'adapters' && segments[5] === 'enabled') {
         // 路径 /coi/adapters/:id/enabled → segments=[memory-evolve,api,coi,adapters,id,enabled] 共 6 段
@@ -110,13 +114,13 @@ export function installCoiApi(ctx, svc) {
       }
       if (req.method === 'GET' && segments.length === 6 && segments[2] === 'coi' && segments[3] === 'adapters' && segments[5] === 'skill') {
         const adapterId = decodeURIComponent(segments[4])
-        const result = svc.readSkill?.(adapterId) ?? { ok: false, message: '技能读写不可用' }
+        const result = svc.readSkill?.(adapterId) ?? { ok: false, message: cap2('coi2.skillIoUnavailable') }
         return sendJson(res, result.ok ? 200 : 404, result)
       }
       if (req.method === 'PUT' && segments.length === 6 && segments[2] === 'coi' && segments[3] === 'adapters' && segments[5] === 'skill') {
         const adapterId = decodeURIComponent(segments[4])
         const body = await readBody(req)
-        const result = svc.writeSkill?.(adapterId, body.content) ?? { ok: false, message: '技能读写不可用' }
+        const result = svc.writeSkill?.(adapterId, body.content) ?? { ok: false, message: cap2('coi2.skillIoUnavailable') }
         return sendJson(res, result.ok ? 200 : 400, result)
       }
       if (req.method === 'GET' && path === `${base}/tasks`) {
@@ -277,13 +281,13 @@ export function installCoiApi(ctx, svc) {
         const body = await readBody(req)
         const adapterId = body.adapterId ?? 'grok'
         const adapter = svc.adapters.get(adapterId)
-        if (!adapter) return sendJson(res, 400, { ok: false, message: `未知适配器 ${adapterId}` })
+        if (!adapter) return sendJson(res, 400, { ok: false, message: cap2('coi2.adapterUnknown', { id: adapterId }) })
         const cmd = adapter.mgmtCmds?.export
-        if (!cmd) return sendJson(res, 400, { ok: false, message: `适配器 ${adapterId} 不支持会话导出` })
+        if (!cmd) return sendJson(res, 400, { ok: false, message: cap2('coi2.exportUnsupportedApi', { id: adapterId }) })
         const outDir = join(svc.config.coiDataDir, 'exports')
         mkdirSync(outDir, { recursive: true })
         const safeId = String(body.sessionId ?? '').replace(/[^a-zA-Z0-9-]/g, '_').slice(0, 24)
-        if (!safeId) return sendJson(res, 400, { ok: false, message: 'sessionId 不能为空' })
+        if (!safeId) return sendJson(res, 400, { ok: false, message: cap2('coi2.sessionIdEmpty') })
         const outFile = join(outDir, `${adapterId}-${safeId}.log`)
         // 加固（P2-4）：导出子进程加 unref（不阻止 DSH 退出）、60s 兜底
         // 超时（挂住就强杀）、输出 64MB 上限（防 chunks 无限吃内存）
@@ -307,9 +311,9 @@ export function installCoiApi(ctx, svc) {
           clearTimeout(exportTimer)
           try { writeFileSync(outFile, Buffer.concat(chunks).toString()) } catch { /* 忽略 */ }
         })
-        return sendJson(res, 200, { ok: true, message: `导出任务已启动，输出将写入 ${outFile}` })
+        return sendJson(res, 200, { ok: true, message: cap2('coi2.exportStartedApi', { outFile }) })
       }
-      return sendJson(res, 404, { ok: false, message: `未知路由 ${path}` })
+      return sendJson(res, 404, { ok: false, message: cap2('coi2.unknownRoute', { path }) })
     } catch (error) {
       return sendJson(res, 400, { ok: false, message: error?.message ?? String(error) })
     }

--- a/lib/coi/attachments.js
+++ b/lib/coi/attachments.js
@@ -23,6 +23,10 @@
  */
 import { mkdirSync, statSync, writeFileSync } from 'node:fs'
 import { basename, extname, join } from 'node:path'
+import { translate, getLocale, COI2_DICT } from '../i18n.js'
+
+/** Translate through COI2_DICT in the active host locale. */
+const ca2 = (key, params) => translate(COI2_DICT, key, params, getLocale())
 
 /** 单次任务最多携带的图片数量（防止参数/体积失控）。 */
 export const MAX_ATTACHMENTS = 5
@@ -86,19 +90,19 @@ function findImageRef(agentsService, sessionId, attachmentId) {
  */
 export async function resolveAttachments(attachments, { outputDir, tag, attachmentsStore, agentsService, sessionId } = {}) {
   if (attachments === undefined || attachments === null) return { ok: true, files: [] }
-  if (!Array.isArray(attachments)) return { ok: false, message: 'attachments 必须是数组' }
+  if (!Array.isArray(attachments)) return { ok: false, message: ca2('coi2.attachMustBeArray') }
   if (attachments.length > MAX_ATTACHMENTS) {
-    return { ok: false, message: `图片附件最多 ${MAX_ATTACHMENTS} 张（收到 ${attachments.length} 张）` }
+    return { ok: false, message: ca2('coi2.attachLimit', { max: MAX_ATTACHMENTS, count: attachments.length }) }
   }
   const files = []
   for (let i = 0; i < attachments.length; i++) {
     const item = attachments[i]
     if (item === null || typeof item !== 'object' || Array.isArray(item)) {
-      return { ok: false, message: `第 ${i + 1} 个附件必须是对象` }
+      return { ok: false, message: ca2('coi2.attachNotObject', { n: i + 1 }) }
     }
     const kind = String(item.kind ?? 'image').trim()
     if (kind !== 'image') {
-      return { ok: false, message: `第 ${i + 1} 个附件类型 "${kind}" 暂不支持（当前仅支持图片 image）` }
+      return { ok: false, message: ca2('coi2.attachKindUnsupported', { n: i + 1, kind }) }
     }
     // 来源三选一校验
     const pathSrc = item.path !== undefined && item.path !== null ? String(item.path).trim() : ''
@@ -106,10 +110,10 @@ export async function resolveAttachments(attachments, { outputDir, tag, attachme
     const idSrc = item.attachmentId !== undefined && item.attachmentId !== null ? String(item.attachmentId).trim() : ''
     const chosen = [pathSrc, urlSrc, idSrc].filter(Boolean)
     if (chosen.length === 0) {
-      return { ok: false, message: `第 ${i + 1} 个附件缺少来源（path / url / attachmentId 三选一）` }
+      return { ok: false, message: ca2('coi2.attachNoSource', { n: i + 1 }) }
     }
     if (chosen.length > 1) {
-      return { ok: false, message: `第 ${i + 1} 个附件来源只能三选一（path / url / attachmentId）` }
+      return { ok: false, message: ca2('coi2.attachMultiSource', { n: i + 1 }) }
     }
     const caption = String(item.caption ?? '').trim() || undefined
     const fileName = String(item.fileName ?? '').trim() || undefined
@@ -120,10 +124,10 @@ export async function resolveAttachments(attachments, { outputDir, tag, attachme
       try {
         statSync(pathSrc)
       } catch {
-        return { ok: false, message: `第 ${i + 1} 个附件本地文件不存在：${pathSrc}` }
+        return { ok: false, message: ca2('coi2.attachFileMissing', { n: i + 1, path: pathSrc }) }
       }
       if (!IMAGE_EXT_RE.test(pathSrc)) {
-        return { ok: false, message: `第 ${i + 1} 个附件不是图片文件（仅支持 png/jpg/jpeg/webp/gif）：${pathSrc}` }
+        return { ok: false, message: ca2('coi2.attachNotImage', { n: i + 1, path: pathSrc }) }
       }
       files.push({
         localPath: pathSrc,
@@ -135,18 +139,18 @@ export async function resolveAttachments(attachments, { outputDir, tag, attachme
     } else if (urlSrc) {
       // 来源二：http(s) URL——下载到附件目录（30s 超时，失败即整体报错）
       if (!/^https?:\/\//i.test(urlSrc)) {
-        return { ok: false, message: `第 ${i + 1} 个附件 url 必须是 http(s) 地址` }
+        return { ok: false, message: ca2('coi2.attachBadUrl', { n: i + 1 }) }
       }
       const target = join(outputDir, `${tag}-${i + 1}${extFrom(fileName ?? urlSrc)}`)
       let buffer
       try {
         const res = await fetch(urlSrc, { signal: AbortSignal.timeout(30_000) })
         if (!res.ok) {
-          return { ok: false, message: `第 ${i + 1} 个附件下载失败（HTTP ${res.status}）：${urlSrc}` }
+          return { ok: false, message: ca2('coi2.attachDownloadHttpFail', { n: i + 1, status: res.status, url: urlSrc }) }
         }
         buffer = Buffer.from(await res.arrayBuffer())
       } catch (error) {
-        return { ok: false, message: `第 ${i + 1} 个附件下载失败：${error?.message ?? String(error)}` }
+        return { ok: false, message: ca2('coi2.attachDownloadFail', { n: i + 1, detail: error?.message ?? String(error) }) }
       }
       writeFileSync(target, buffer)
       files.push({
@@ -161,7 +165,7 @@ export async function resolveAttachments(attachments, { outputDir, tag, attachme
       if (!attachmentsStore || typeof attachmentsStore.readImage !== 'function') {
         return {
           ok: false,
-          message: `第 ${i + 1} 个附件引用会话图片需要 DSH 新快照运行时的 attachments 服务（当前进程不支持），请改用 path/url 来源，或重启 DSH 后重试`,
+          message: ca2('coi2.attachSessionNeedsRuntime', { n: i + 1 }),
         }
       }
       // 先从发起会话事件解析完整 ref（readImage 校验需要 bytes/width/height）
@@ -169,17 +173,17 @@ export async function resolveAttachments(attachments, { outputDir, tag, attachme
       if (!ref) {
         return {
           ok: false,
-          message: `第 ${i + 1} 个附件在发起会话中未找到匹配的图片（attachmentId=${idSrc}）——图片须来自当前会话消息（浏览器输入框贴图）`,
+          message: ca2('coi2.attachSessionNotFound', { n: i + 1, id: idSrc }),
         }
       }
       let stored
       try {
         stored = await attachmentsStore.readImage(ref)
       } catch (error) {
-        return { ok: false, message: `第 ${i + 1} 个附件读取会话图片失败：${error?.message ?? String(error)}` }
+        return { ok: false, message: ca2('coi2.attachSessionReadFail', { n: i + 1, detail: error?.message ?? String(error) }) }
       }
       const data = stored?.data
-      if (!data) return { ok: false, message: `第 ${i + 1} 个附件读取会话图片失败：未返回数据` }
+      if (!data) return { ok: false, message: ca2('coi2.attachSessionNoData', { n: i + 1 }) }
       const mediaType = stored?.ref?.mediaType ?? ref.mediaType
       const ext = `.${(mediaType.split('/')[1] ?? 'png').replace('jpeg', 'jpg')}`
       const target = join(outputDir, `${tag}-${i + 1}${ext}`)

--- a/lib/coi/broadcast-api.js
+++ b/lib/coi/broadcast-api.js
@@ -70,7 +70,7 @@ export function installBroadcastApi(ctx, svc) {
         const id = decodeURIComponent(rest.slice(0, rest.lastIndexOf('/attachment/')))
         const msg = svc.broadcast.items.find((m) => m.id === id)
         const att = msg && Array.isArray(msg.attachments) ? msg.attachments[index] : undefined
-        if (!att || typeof att.file !== 'string') return sendJson(res, 404, { ok: false, message: `附件不存在（消息 ${id} 第 ${index} 张）` })
+        if (!att || typeof att.file !== 'string') return sendJson(res, 404, { ok: false, message: cbp2('coi2.attMissingInMsg', { id, index }) })
         const { readFileSync } = await import('node:fs')
         try {
           const buf = readFileSync(att.file)
@@ -82,14 +82,14 @@ export function installBroadcastApi(ctx, svc) {
           res.end(buf)
           return
         } catch {
-          return sendJson(res, 404, { ok: false, message: `附件文件缺失（${att.name}）` })
+          return sendJson(res, 404, { ok: false, message: cbp2('coi2.attFileMissing', { name: att.name }) })
         }
       }
       // 消息全文（含长内容文件）
       if (req.method === 'GET' && path.startsWith(`${base}/messages/`) && path.endsWith('/content')) {
         const id = decodeURIComponent(path.slice(`${base}/messages/`.length, -'/content'.length))
         const msg = svc.broadcast.items.find((m) => m.id === id)
-        if (!msg) return sendJson(res, 404, { ok: false, message: `消息 ${id} 不存在` })
+        if (!msg) return sendJson(res, 404, { ok: false, message: cbp2('coi2.msgMissing', { id }) })
         let content = msg.content
         if (msg.bodyFile) {
           const { readFileSync } = await import('node:fs')
@@ -127,7 +127,7 @@ export function installBroadcastApi(ctx, svc) {
       if (req.method === 'GET' && path.startsWith(`${base}/rooms/`) && path.endsWith('/presence')) {
         const id = decodeURIComponent(path.slice(`${base}/rooms/`.length, -'/presence'.length))
         const room = svc.broadcast.rooms.get(id)
-        if (!room) return sendJson(res, 404, { ok: false, message: `房间 ${id} 不存在` })
+        if (!room) return sendJson(res, 404, { ok: false, message: cbp2('coi2.roomMissing', { id }) })
         const presence = svc.presence ? svc.presence.roomStatus(room) : room.members.map((sid) => ({ sessionId: sid, status: 'unknown', online: false, lastActiveAt: null }))
         return sendJson(res, 200, { ok: true, presence })
       }
@@ -148,7 +148,7 @@ export function installBroadcastApi(ctx, svc) {
         const id = decodeURIComponent(path.slice(`${base}/rooms/`.length, -'/kick'.length))
         const body = await readBody(req)
         const room = svc.broadcast.rooms.get(id)
-        if (!room) return sendJson(res, 404, { ok: false, message: `房间 ${id} 不存在` })
+        if (!room) return sendJson(res, 404, { ok: false, message: cbp2('coi2.roomMissing', { id }) })
         const result = svc.broadcast.rooms.kick(id, String(body.member ?? '').trim())
         if (result.ok) {
           svc.broadcast.send({
@@ -160,7 +160,7 @@ export function installBroadcastApi(ctx, svc) {
         }
         return sendJson(res, result.ok ? 200 : 400, result)
       }
-      return sendJson(res, 404, { ok: false, message: `未知路由 ${path}` })
+      return sendJson(res, 404, { ok: false, message: cbp2('coi2.unknownRouteB', { path }) })
     } catch (error) {
       return sendJson(res, 400, { ok: false, message: error?.message ?? String(error) })
     }

--- a/lib/coi/broadcast.js
+++ b/lib/coi/broadcast.js
@@ -26,6 +26,10 @@
 import { mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { basename, dirname, extname, join } from 'node:path'
 import { readAliases } from '../aliases.js'
+import { translate, getLocale, BROADCAST_DICT } from '../i18n.js'
+
+/** Translate through BROADCAST_DICT in the active host locale. */
+const bt = (key, params) => translate(BROADCAST_DICT, key, params, getLocale())
 
 /** 内容内联上限：超过则写入 broadcasts/<id>.txt（消息体不膨胀 JSON）。 */
 const INLINE_MAX = 8192
@@ -106,7 +110,7 @@ export async function resolveAttachments(dir, messageId, raw) {
   const list = Array.isArray(raw) ? raw : []
   if (list.length === 0) return { ok: true, attachments: [] }
   if (list.length > ATTACH_MAX_COUNT) {
-    return { ok: false, message: `图片附件数量超限：最多 ${ATTACH_MAX_COUNT} 张（收到 ${list.length} 张）` }
+    return { ok: false, message: bt('bc.attachLimit', { max: ATTACH_MAX_COUNT, count: list.length }) }
   }
   const attDir = join(dir, 'attachments')
   mkdirSync(attDir, { recursive: true })
@@ -234,7 +238,7 @@ export class RoomStore {
    */
   create({ name, createdBy } = {}) {
     const creator = String(createdBy ?? '').trim()
-    if (!creator) return { ok: false, message: '创建者会话 id 不能为空' }
+    if (!creator) return { ok: false, message: bt('bc.needsCreator') }
     const id = newRoomId()
     const now = Date.now()
     const room = {
@@ -248,26 +252,26 @@ export class RoomStore {
     }
     this.rooms[id] = room
     this.#save()
-    return { ok: true, message: `房间「${room.name}」已创建（你是成员；告诉其他人房间 id ${id} 让它们 room-join）`, room }
+    return { ok: true, message: bt('bc.roomCreated', { name: room.name, id }), room }
   }
 
   /** 加入房间（幂等；已解散房间拒绝）。 */
   join(id, sessionId) {
     const room = this.rooms[id]
-    if (!room) return { ok: false, message: `房间 ${id} 不存在（请向创建者确认房间 id）` }
-    if (room.status === 'dissolved') return { ok: false, message: `房间「${room.name}」已解散，无法加入` }
+    if (!room) return { ok: false, message: bt('bc.roomMissingJoin', { id }) }
+    if (room.status === 'dissolved') return { ok: false, message: bt('bc.roomDissolved', { name: room.name }) }
     if (!room.members.includes(sessionId)) {
       room.members.push(sessionId)
       this.#save()
     }
     this.touch(id) // 加入算活动（刷新清理计时）
-    return { ok: true, message: `已加入房间「${room.name}」（成员 ${room.members.length} 人）`, room }
+    return { ok: true, message: bt('bc.joined', { name: room.name, count: room.members.length }), room }
   }
 
   /** 退出房间（最后一个成员退出后房间自动删除）。 */
   leave(id, sessionId) {
     const room = this.rooms[id]
-    if (!room) return { ok: false, message: `房间 ${id} 不存在` }
+    if (!room) return { ok: false, message: bt('bc.roomMissing', { id }) }
     room.members = room.members.filter((s) => s !== sessionId)
     if (room.members.length === 0) {
       // 最后一人退出 = 房间解散（**软删除**，与 room-rm 一致：标记
@@ -276,10 +280,10 @@ export class RoomStore {
       room.status = 'dissolved'
       room.dissolvedAt = Date.now()
       this.#save()
-      return { ok: true, message: `已退出，房间 ${id} 无成员已解散（记录保留可追溯）` }
+      return { ok: true, message: bt('bc.leftAutoDissolved', { id }) }
     }
     this.#save()
-    return { ok: true, message: `已退出房间「${room.name}」（剩 ${room.members.length} 人）`, room }
+    return { ok: true, message: bt('bc.left', { name: room.name, count: room.members.length }), room }
   }
 
   /**
@@ -332,13 +336,13 @@ export class RoomStore {
    */
   dissolve(id, sessionId) {
     const room = this.rooms[id]
-    if (!room) return { ok: false, message: `房间 ${id} 不存在` }
-    if (sessionId && room.createdBy !== sessionId) return { ok: false, message: '只有创建者可以解散房间' }
-    if (room.status === 'dissolved') return { ok: true, message: `房间「${room.name}」已是解散状态`, room }
+    if (!room) return { ok: false, message: bt('bc.roomMissing', { id }) }
+    if (sessionId && room.createdBy !== sessionId) return { ok: false, message: bt('bc.onlyCreatorDissolve') }
+    if (room.status === 'dissolved') return { ok: true, message: bt('bc.alreadyDissolved', { name: room.name }), room }
     room.status = 'dissolved'
     room.dissolvedAt = Date.now()
     this.#save()
-    return { ok: true, message: `房间「${room.name}」已解散`, room }
+    return { ok: true, message: bt('bc.dissolved', { name: room.name }), room }
   }
 
   /**
@@ -350,19 +354,19 @@ export class RoomStore {
    */
   kick(id, member) {
     const room = this.rooms[id]
-    if (!room) return { ok: false, message: `房间 ${id} 不存在` }
-    if (room.status === 'dissolved') return { ok: false, message: `房间「${room.name}」已解散` }
-    if (!room.members.includes(member)) return { ok: false, message: `成员 ${member} 不在房间中` }
+    if (!room) return { ok: false, message: bt('bc.roomMissing', { id }) }
+    if (room.status === 'dissolved') return { ok: false, message: bt('bc.dissolved', { name: room.name }) }
+    if (!room.members.includes(member)) return { ok: false, message: bt('bc.memberNotInRoom', { member }) }
     room.members = room.members.filter((s) => s !== member)
     if (room.members.length === 0) {
       // 最后一个成员被踢：直接解散（空房不留，等同全员退出）
       room.status = 'dissolved'
       room.dissolvedAt = Date.now()
       this.#save()
-      return { ok: true, message: `已踢出 ${member}，房间无成员已解散`, room }
+      return { ok: true, message: bt('bc.kickedAutoDissolved', { member }), room }
     }
     this.#save()
-    return { ok: true, message: `已踢出成员 ${member}（剩 ${room.members.length} 人）`, room }
+    return { ok: true, message: bt('bc.kicked', { member, count: room.members.length }), room }
   }
 }
 
@@ -478,11 +482,11 @@ export class BroadcastStore {
    */
   send(req) {
     const sender = String(req.sender ?? '').trim()
-    if (!sender) return { ok: false, message: '发送方会话 id 不能为空' }
+    if (!sender) return { ok: false, message: bt('bc.needsSender') }
     let recipients = Array.isArray(req.recipients)
       ? [...new Set(req.recipients.map((r) => String(r).trim()).filter((r) => r !== ''))]
       : []
-    if (recipients.length === 0) return { ok: false, message: 'recipients 必须是非空数组（会话 ID 或 room:/project: 伪接收者）' }
+    if (recipients.length === 0) return { ok: false, message: bt('bc.badRecipients') }
     // 伪接收者校验 + 规范化存储（裸房间 id room-xxx 统一存 room:<id> 形式，
     // 便于显示与后续判断一致）：房间必须存在且发送者是成员；project: 路径非空
     const normalized = []
@@ -490,15 +494,15 @@ export class BroadcastStore {
       const ref = parseRef(r)
       if (ref.type === 'room') {
         const room = this.rooms.get(ref.value)
-        if (!room) return { ok: false, message: `房间 ${r} 不存在（先 room-create，或向创建者确认房间 id 后 room-join）` }
-        if (room.status === 'dissolved') return { ok: false, message: `房间「${room.name}」已解散，无法发消息` }
+        if (!room) return { ok: false, message: bt('bc.sendRoomMissing', { id: r }) }
+        if (room.status === 'dissolved') return { ok: false, message: bt('bc.sendRoomDissolved', { name: room.name }) }
         if (!room.members.includes(sender)) {
-          return { ok: false, message: `你不是房间「${room.name}」的成员（先 room-join 加入）` }
+          return { ok: false, message: bt('bc.notMember', { name: room.name }) }
         }
         normalized.push(`room:${ref.value}`)
         this.rooms.touch(ref.value) // 发消息到房间 = 房间活动（刷新清理计时）
       } else if (ref.type === 'project') {
-        if (ref.value === '') return { ok: false, message: 'project: 后必须跟工作目录绝对路径，如 project:/Volumes/data/proj' }
+        if (ref.value === '') return { ok: false, message: bt('bc.projectNeedsPath') }
         normalized.push(`project:${ref.value}`)
       } else {
         normalized.push(r)
@@ -506,7 +510,7 @@ export class BroadcastStore {
     }
     recipients = normalized
     const content = String(req.content ?? '').trim()
-    if (!content) return { ok: false, message: '消息内容不能为空' }
+    if (!content) return { ok: false, message: bt('bc.emptyContent') }
     // 主题：显式传入优先；缺省取内容首行（strip markdown 标题符号）截 40 字符
     const subject = String(req.subject ?? '').trim() !== ''
       ? String(req.subject).trim()
@@ -542,7 +546,7 @@ export class BroadcastStore {
     this.#save()
     // 注意：消息对象放 item 字段（message 字段被 DSH 工具 schema 要求为
     // string——曾误用 message: msg 覆盖提示文本导致工具输出校验失败）
-    return { ok: true, message: `广播已发送（${recipients.length} 个接收目标${attachments.length > 0 ? `，图片 ${attachments.length} 张` : ''}）`, item: msg }
+    return { ok: true, message: bt('bc.sent', { count: recipients.length, tail: attachments.length > 0 ? bt('bc.sentImages', { count: attachments.length }) : '' }), item: msg }
   }
 
   /**
@@ -587,8 +591,8 @@ export class BroadcastStore {
    */
   read(id, sessionId, cwd) {
     const msg = this.items.find((m) => m.id === id)
-    if (!msg) return { ok: false, message: `消息 ${id} 不存在` }
-    if (!this.visibleTo(msg, sessionId, cwd)) return { ok: false, message: '该消息对当前会话不可见，无法读取' }
+    if (!msg) return { ok: false, message: bt('bc.msgMissing', { id }) }
+    if (!this.visibleTo(msg, sessionId, cwd)) return { ok: false, message: bt('bc.msgInvisible') }
     // 长内容：先取全文（消息可能随后被自动删除，文件会被一并清理）
     let content = msg.content
     if (msg.bodyFile) {
@@ -612,7 +616,7 @@ export class BroadcastStore {
       }
       this.#save()
     }
-    return { ok: true, message: `消息 ${msg.id}（${msg.sender} → ${msg.recipients.join(',')}）`, item: { ...msg, content } }
+    return { ok: true, message: bt('bc.msgDetail', { id: msg.id, sender: msg.sender, recipients: msg.recipients.join(',') }), item: { ...msg, content } }
   }
 
   /**
@@ -625,15 +629,15 @@ export class BroadcastStore {
    */
   remove(id, sessionId, cwd) {
     const index = this.items.findIndex((m) => m.id === id)
-    if (index < 0) return { ok: false, message: `消息 ${id} 不存在` }
+    if (index < 0) return { ok: false, message: bt('bc.msgMissing', { id }) }
     const msg = this.items[index]
     if (msg.sender !== sessionId && !this.visibleTo(msg, sessionId, cwd)) {
-      return { ok: false, message: '只有发送方或接收方可删除该消息' }
+      return { ok: false, message: bt('bc.onlySenderOrRecipient') }
     }
     this.items.splice(index, 1)
     this.#save()
     this.#cleanup(msg) // 长内容文件 + 附件文件一并清理
-    return { ok: true, message: `已删除消息 ${id}` }
+    return { ok: true, message: bt('bc.deleted', { id }) }
   }
 
   /**
@@ -643,11 +647,11 @@ export class BroadcastStore {
    */
   adminRemove(id) {
     const index = this.items.findIndex((m) => m.id === id)
-    if (index < 0) return { ok: false, message: `消息 ${id} 不存在` }
+    if (index < 0) return { ok: false, message: bt('bc.msgMissing', { id }) }
     const [msg] = this.items.splice(index, 1)
     this.#save()
     this.#cleanup(msg) // 长内容文件 + 附件文件一并清理
-    return { ok: true, message: `已删除消息 ${id}` }
+    return { ok: true, message: bt('bc.deleted', { id }) }
   }
 
   /**
@@ -944,7 +948,7 @@ export function messageToolDefinition(broadcast, presence, memoryDir, svc, image
         // 受 broadcastImageEnabled 子开关控制（关=明确报错，不静默忽略）。
         const rawAttachments = Array.isArray(args.attachments) && args.attachments.length > 0 ? args.attachments : []
         if (rawAttachments.length > 0 && imageEnabled !== true) {
-          return { ok: false, message: '图片附件未启用（配置项 broadcastImageEnabled=false；开启后才能带图发送）' }
+          return { ok: false, message: bt('bc.imagesDisabled') }
         }
         // 附件解析需要消息 id 做存储文件名前缀：先占一个 id（send 支持
         // req.id 覆盖——resolveAttachments 失败时消息未发出、无孤儿记录）
@@ -952,7 +956,7 @@ export function messageToolDefinition(broadcast, presence, memoryDir, svc, image
         let attachments = []
         if (rawAttachments.length > 0) {
           const resolved = await resolveAttachments(broadcast.dir, msgId, rawAttachments)
-          if (!resolved.ok) return { ok: false, message: `附件处理失败：${resolved.message}` }
+          if (!resolved.ok) return { ok: false, message: bt('bc.attachFailed', { detail: resolved.message }) }
           attachments = resolved.attachments ?? []
         }
         // 只回传 ok/message（store 的 item 字段不在输出 schema 内，
@@ -995,7 +999,7 @@ export function messageToolDefinition(broadcast, presence, memoryDir, svc, image
             }
           })
         const label = type === 'unread' ? '未读' : type === 'read' ? '已读' : '全部'
-        return { ok: true, message: `消息（${label} ${items.length} 条）`, messages: items }
+        return { ok: true, message: bt('bc.listHead', { label, count: items.length }), messages: items }
       }
       if (action === 'read') {
         // 单条（id）或批量（ids 数组）——AI 清空收件箱高频场景：传多个
@@ -1004,7 +1008,7 @@ export function messageToolDefinition(broadcast, presence, memoryDir, svc, image
         const idList = Array.isArray(args.ids) && args.ids.length > 0
           ? [...new Set(args.ids)]
           : (args.id ? [args.id] : [])
-        if (idList.length === 0) return { ok: false, message: 'read 必填 id 或 ids（消息 id）' }
+        if (idList.length === 0) return { ok: false, message: bt('bc.readNeedsIds') }
         const results = []
         let skipped = 0
         for (const mid of idList) {
@@ -1027,7 +1031,7 @@ export function messageToolDefinition(broadcast, presence, memoryDir, svc, image
         }
         return {
           ok: true,
-          message: `已读取 ${results.length} 条${skipped > 0 ? `，跳过 ${skipped} 条（不可见/不存在）` : ''}`,
+          message: bt('bc.readDone', { count: results.length, tail: skipped > 0 ? bt('bc.readSkipped', { count: skipped }) : '' }),
           messages: results,
         }
       }
@@ -1104,8 +1108,8 @@ export function messageToolDefinition(broadcast, presence, memoryDir, svc, image
       }
       if (action === 'room-kick') {
         const room = broadcast.rooms.get(args.roomId)
-        if (!room) return { ok: false, message: `房间 ${args.roomId} 不存在` }
-        if (room.createdBy !== sessionId) return { ok: false, message: '只有创建者可以踢人' }
+        if (!room) return { ok: false, message: bt('bc.kickRoomMissing', { id: args.roomId }) }
+        if (room.createdBy !== sessionId) return { ok: false, message: bt('bc.onlyCreatorKick') }
         const result = broadcast.rooms.kick(args.roomId, args.member)
         // 系统通知被踢者（可感知：踢出不是无声消失）
         if (result.ok) {
@@ -1117,16 +1121,16 @@ export function messageToolDefinition(broadcast, presence, memoryDir, svc, image
         // 在线状态查询：roomId → 房间成员列表；sessionId → 单个会话。
         // 每个成员补会话名称/别名（memberView：live 会话名称 + aliases.json
         // 别名，任一不可用 null 兼容——见函数上方注释）
-        if (presence === undefined) return { ok: false, message: '在线状态追踪未启用' }
+        if (presence === undefined) return { ok: false, message: bt('bc.presenceDisabled') }
         if (args.sessionId) {
-          return { ok: true, message: `会话 ${args.sessionId} 状态`, presence: [memberView(presence.get(args.sessionId))] }
+          return { ok: true, message: bt('bc.presenceOne', { sid: args.sessionId }), presence: [memberView(presence.get(args.sessionId))] }
         }
         const room = broadcast.rooms.get(args.roomId)
-        if (!room) return { ok: false, message: `房间 ${args.roomId} 不存在` }
+        if (!room) return { ok: false, message: bt('bc.kickRoomMissing', { id: args.roomId }) }
         const list = presence.roomStatus(room).map(memberView)
-        return { ok: true, message: `房间「${room.name}」成员在线状态（${list.filter((p) => p.online).length}/${list.length} 在线）`, presence: list }
+        return { ok: true, message: bt('bc.presenceList', { name: room.name, online: list.filter((p) => p.online).length, total: list.length }), presence: list }
       }
-      return { ok: false, message: `未知 action "${action}"` }
+      return { ok: false, message: bt('bc.unknownAction', { action }) }
     },
   }
 }

--- a/lib/coi/commands.js
+++ b/lib/coi/commands.js
@@ -7,6 +7,10 @@
 import { spawn } from 'node:child_process'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { translate, getLocale, COI_DICT, HELP_EXTRA } from '../i18n.js'
+
+/** Translate through COI_DICT in the active host locale. */
+const cmt = (key, params) => translate(COI_DICT, key, params, getLocale())
 
 /** 简易 tokenizer：支持双引号包裹的参数。 */
 function tokenize(input) {
@@ -79,7 +83,7 @@ async function handle(svc, sub, rest, invocation) {
       // --inject-tracks 是带值选项（逗号分隔的注入轨），不列入 flagNames
       const { opts, positional } = parseOpts(rest, ['continue', 'all'])
       const prompt = positional.join(' ')
-      if (!prompt && !opts.template) return { kind: 'error', text: '用法：/de_coi run "<任务>" [--coi kimi] [--scope session] [--session <id>] [--branch <b>] [--model <m>] [--ref <taskId>] [--template <id>] [--continue] [--inject-tracks memory,user,key] [--context-text <文本>]' }
+      if (!prompt && !opts.template) return { kind: 'error', text: cmt('coicmd.runUsage') }
       const result = svc.scheduler.dispatch({
         adapterId: opts.coi ?? 'kimi',
         prompt,
@@ -99,7 +103,7 @@ async function handle(svc, sub, rest, invocation) {
         contextText: opts['context-text'],
       })
       return result.ok
-        ? { kind: 'success', text: `✅ ${result.message}\n查看进度：/de_coi log ${result.taskId}` }
+        ? { kind: 'success', text: cmt('coicmd.dispatched', { message: result.message, taskId: result.taskId }) }
         : { kind: 'error', text: result.message }
     }
     case 'list': {
@@ -111,18 +115,18 @@ async function handle(svc, sub, rest, invocation) {
         q: opts.q,
         limit: Number(opts.limit ?? 15),
       })
-      if (tasks.length === 0) return { kind: 'success', text: '（暂无任务）' }
+      if (tasks.length === 0) return { kind: 'success', text: cmt('coicmd.noTasks') }
       const lines = tasks.map((t) => {
         const when = new Date(t.createdAt).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
         const mark = { running: '⏳', completed: '✅', failed: '❌', killed: '🛑', interrupted: '⚠️', queued: '⏸️' }[t.status] ?? '·'
         return `${mark} ${t.id} [${t.adapterId}] ${t.status} ${when} ${String(t.prompt ?? '').slice(0, 40)}`
       })
-      return { kind: 'success', text: `任务（${tasks.length} 条）：\n${lines.join('\n')}` }
+      return { kind: 'success', text: cmt('coicmd.taskList', { count: tasks.length, lines: lines.join('\n') }) }
     }
     case 'log': {
       const { opts, positional } = parseOpts(rest, [])
       const taskId = positional[0]
-      if (!taskId) return { kind: 'error', text: '用法：/de_coi log <taskId> [--tail <字符数>]' }
+      if (!taskId) return { kind: 'error', text: cmt('coicmd.logUsage') }
       const result = svc.scheduler.getLog(taskId, Number(opts.tail ?? 4000))
       if (!result.ok) return { kind: 'error', text: result.message }
       return { kind: 'success', text: result.text.slice(-(Number(opts.tail ?? 4000))) || '（无输出）' }
@@ -130,18 +134,18 @@ async function handle(svc, sub, rest, invocation) {
     case 'stop': {
       const { opts, positional } = parseOpts(rest, ['force', 'all', 'yes'])
       const taskId = positional[0]
-      if (!taskId) return { kind: 'error', text: '用法：/de_coi stop <taskId> [--force]（终止需二次确认；--all 需同时带 --force）' }
+      if (!taskId) return { kind: 'error', text: cmt('coicmd.stopUsage') }
       if (taskId === '--all') {
-        if (!opts.force) return { kind: 'error', text: '⚠️ 终止全部任务需二次确认：/de_coi stop --all --force' }
+        if (!opts.force) return { kind: 'error', text: cmt('coicmd.stopAllConfirm') }
         const running = svc.tasks.list({ status: 'running' }).filter((t) => svc.scheduler.status(t.id).task?.status === 'running')
         for (const t of running) svc.scheduler.cancel(t.id, { force: true })
-        return { kind: 'success', text: `已终止 ${running.length} 个任务` }
+        return { kind: 'success', text: cmt('coicmd.stoppedMany', { count: running.length }) }
       }
       if (!opts.force && !opts.yes) {
         const info = svc.scheduler.status(taskId)
         const task = info.task
         if (!task) return { kind: 'error', text: info.message }
-        return { kind: 'error', text: `⚠️ 确认终止任务 ${taskId}（${task.coi}：${String(task.prompt ?? '').slice(0, 60)}）？确认请再次执行：/de_coi stop ${taskId} --force` }
+        return { kind: 'error', text: cmt('coicmd.stopOneConfirm', { id: taskId, adapter: task.coi, preview: String(task.prompt ?? '').slice(0, 60) }) }
       }
       const result = svc.scheduler.cancel(taskId, { force: true })
       return result.ok ? { kind: 'success', text: result.message } : { kind: 'error', text: result.message }
@@ -151,27 +155,27 @@ async function handle(svc, sub, rest, invocation) {
       const action = positional[0] ?? 'list'
       if (action === 'list') {
         const sessions = svc.sessions.list({ scope: opts.scope, branch: opts.branch, q: opts.q, adapterId: opts.coi })
-        if (sessions.length === 0) return { kind: 'success', text: '（暂无会话记录）' }
+        if (sessions.length === 0) return { kind: 'success', text: cmt('coicmd.noSessions') }
         const lines = sessions.slice(0, Number(opts.limit ?? 20)).map((s) => {
           const lock = s.activeTaskId ? ` [占用:${s.activeTaskId}]` : ''
           return `${s.id} [${s.adapterId}] ${s.scope}${s.branch ? ` @${s.branch}` : ''}${s.note ? ` "${s.note}"` : ''}${lock}`
         })
-        return { kind: 'success', text: `会话（${sessions.length} 条）：\n${lines.join('\n')}` }
+        return { kind: 'success', text: cmt('coicmd.sessionList', { count: sessions.length, lines: lines.join('\n') }) }
       }
       if (action === 'note') {
         const id = positional[1]
         const note = positional.slice(2).join(' ')
-        if (!id || !note) return { kind: 'error', text: '用法：/de_coi sessions note <sessionId> <备注>' }
+        if (!id || !note) return { kind: 'error', text: cmt('coicmd.noteUsage') }
         const result = svc.sessions.updateNote(id, note)
         return result.ok ? { kind: 'success', text: result.message } : { kind: 'error', text: result.message }
       }
       if (action === 'rm' || action === 'remove') {
         const id = positional[1]
-        if (!id) return { kind: 'error', text: '用法：/de_coi sessions rm <sessionId>' }
+        if (!id) return { kind: 'error', text: cmt('coicmd.rmUsage') }
         const result = svc.sessions.remove(id)
         return result.ok ? { kind: 'success', text: result.message } : { kind: 'error', text: result.message }
       }
-      return { kind: 'error', text: 'sessions 子命令：list / note <id> <备注> / rm <id>' }
+      return { kind: 'error', text: cmt('coicmd.sessionsSubs') }
     }
     case 'adapters': {
       const { positional } = parseOpts(rest, [])
@@ -185,8 +189,8 @@ async function handle(svc, sub, rest, invocation) {
       }
       if (action === 'show') {
         const adapter = svc.adapters.get(positional[1])
-        if (!adapter) return { kind: 'error', text: `未知适配器 ${positional[1]}` }
-        return { kind: 'success', text: `${adapter.id} — ${adapter.name}\n类型：${adapter.type}\n命令：${adapter.binary} ${adapter.args.join(' ')}\n${adapter.guide ? `\n指南：\n${adapter.guide}` : ''}` }
+        if (!adapter) return { kind: 'error', text: cmt('coicmd.adapterUnknown', { id: positional[1] }) }
+        return { kind: 'success', text: cmt('coicmd.adapterShow', { id: adapter.id, name: adapter.name, type: adapter.type, cmd: `${adapter.binary} ${adapter.args.join(' ')}`, guide: adapter.guide ? cmt('coicmd.adapterGuide', { guide: adapter.guide }) : '' }) }
       }
       if (action === 'test') {
         const result = svc.scheduler.testAdapter(positional[1])
@@ -196,7 +200,7 @@ async function handle(svc, sub, rest, invocation) {
         const result = svc.adapters.setEnabled(positional[1], action === 'enable')
         return result.ok ? { kind: 'success', text: result.message } : { kind: 'error', text: result.message }
       }
-      return { kind: 'error', text: 'adapters 子命令：list / show <id> / test <id> / enable <id> / disable <id>' }
+      return { kind: 'error', text: cmt('coicmd.adaptersSubs') }
     }
     case 'stats': {
       const { coiStats } = await import('./stats.js')
@@ -215,17 +219,17 @@ async function handle(svc, sub, rest, invocation) {
         const templates = svc.templates.list()
         return { kind: 'success', text: templates.length === 0 ? '（暂无模板）' : templates.map((t) => `${t.id} — ${t.name}${t.adapterId ? ` [${t.adapterId}]` : ''}\n    ${t.prompt.slice(0, 60)}`).join('\n') }
       }
-      return { kind: 'error', text: 'templates 子命令：list' }
+      return { kind: 'error', text: cmt('coicmd.templatesSubs') }
     }
     case 'export': {
       const { opts, positional } = parseOpts(rest, [])
       const sessionId = positional[0]
-      if (!sessionId) return { kind: 'error', text: '用法：/de_coi export <sessionId> [--coi kimi]' }
+      if (!sessionId) return { kind: 'error', text: cmt('coicmd.exportUsage') }
       const adapterId = opts.coi ?? 'grok'
       const adapter = svc.adapters.get(adapterId)
-      if (!adapter) return { kind: 'error', text: `未知适配器 ${adapterId}` }
+      if (!adapter) return { kind: 'error', text: cmt('coicmd.adapterUnknown', { id: adapterId }) }
       const cmd = adapter.mgmtCmds?.export
-      if (!cmd) return { kind: 'error', text: `适配器 ${adapterId} 不支持会话导出` }
+      if (!cmd) return { kind: 'error', text: cmt('coicmd.exportUnsupported', { id: adapterId }) }
       const outDir = join(svc.config.coiDataDir, 'exports')
       mkdirSync(outDir, { recursive: true })
       const outFile = join(outDir, `${adapterId}-${sessionId.replace(/[^a-zA-Z0-9-]/g, '_').slice(0, 24)}.log`)
@@ -251,22 +255,13 @@ async function handle(svc, sub, rest, invocation) {
         clearTimeout(exportTimer)
         writeFileSync(outFile, Buffer.concat(chunks).toString())
       })
-      return { kind: 'success', text: `导出任务已启动（${adapter.binary} ${cmd.join(' ')} ${sessionId}），完成后输出在 ${outFile}` }
+      return { kind: 'success', text: cmt('coicmd.exportStarted', { cmd: `${adapter.binary} ${cmd.join(' ')} ${sessionId}`, outFile }) }
     }
     case 'help':
     default:
       return {
         kind: 'success',
-        text: `de_coi — COI 调度命令族
-  /de_coi run "<任务>" [--coi kimi|codex|grok|hermes] [--scope temporary|session|project|global] [--session <id>] [--branch <b>] [--model <m>] [--ref <taskId>] [--template <id>] [--continue] [--inject-context] [--context-text <文本>]
-  /de_coi list [--coi <id>] [--status <s>] [--limit <n>] [--q <关键词>]
-  /de_coi log <taskId> [--tail <字符数>]
-  /de_coi stop <taskId> [--force]（终止需二次确认；--all 需 --force --all）
-  /de_coi sessions [list|note <id> <备注>|rm <id>] [--scope] [--branch] [--q]
-  /de_coi adapters [list|show <id>|test <id>|enable <id>|disable <id>]
-  /de_coi stats
-  /de_coi templates list
-  /de_coi export <sessionId> [--coi <id>]`,
+        text: translate(HELP_EXTRA, 'coicmd.help', undefined, getLocale()),
       }
   }
 }

--- a/lib/coi/index.js
+++ b/lib/coi/index.js
@@ -10,6 +10,10 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { dirname, join } from 'node:path'
+import { translate, getLocale, COI2_DICT } from '../i18n.js'
+
+/** Translate through COI2_DICT in the active host locale. */
+const cix2 = (key, params) => translate(COI2_DICT, key, params, getLocale())
 import { fileURLToPath } from 'node:url'
 import { AdapterStore } from './adapters.js'
 import { SessionStore } from './session-store.js'
@@ -298,16 +302,16 @@ export function installCoi(ctx, config, deps) {
      */
     readSkill: (adapterId) => {
       const adapter = adapters.get(adapterId)
-      if (!adapter) return { ok: false, message: `未知适配器 "${adapterId}"` }
+      if (!adapter) return { ok: false, message: cix2('coi2.adapterUnknown', { id: adapterId }) }
       const skillName = adapter.skillName
-      if (!skillName) return { ok: false, message: `适配器 ${adapterId} 未关联技能` }
+      if (!skillName) return { ok: false, message: cix2('coi2.adapterNoSkill', { id: adapterId }) }
       const file = join(config.skillDir, skillName, 'SKILL.md')
       try {
         const content = readFileSync(file, 'utf8')
         return { ok: true, skillName, exists: true, path: file, content }
       } catch (error) {
         if (error.code === 'ENOENT') return { ok: true, skillName, exists: false, path: file, content: '' }
-        return { ok: false, message: `读取技能失败: ${error.message}` }
+        return { ok: false, message: cix2('coi2.skillReadFailed', { detail: error.message }) }
       }
     },
     /**
@@ -319,9 +323,9 @@ export function installCoi(ctx, config, deps) {
      */
     writeSkill: (adapterId, content) => {
       const adapter = adapters.get(adapterId)
-      if (!adapter) return { ok: false, message: `未知适配器 "${adapterId}"` }
+      if (!adapter) return { ok: false, message: cix2('coi2.adapterUnknown', { id: adapterId }) }
       const skillName = adapter.skillName
-      if (!skillName) return { ok: false, message: `适配器 ${adapterId} 未关联技能` }
+      if (!skillName) return { ok: false, message: cix2('coi2.adapterNoSkill', { id: adapterId }) }
       let text
       try {
         text = normalizeSkillText(content, skillName, adapter.name)
@@ -332,9 +336,9 @@ export function installCoi(ctx, config, deps) {
       try {
         mkdirSync(dirname(file), { recursive: true })
         writeFileSync(file, text)
-        return { ok: true, message: `技能 ${skillName} 已保存（源头为插件内置，重启时版本未变不会覆盖你的编辑）` }
+        return { ok: true, message: cix2('coi2.skillSaved', { skill: skillName }) }
       } catch (error) {
-        return { ok: false, message: `保存技能失败: ${error.message}` }
+        return { ok: false, message: cix2('coi2.skillSaveFailed', { detail: error.message }) }
       }
     },
     updateRuntimeConfig: (patch) => {

--- a/lib/coi/index.js
+++ b/lib/coi/index.js
@@ -10,7 +10,10 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { dirname, join } from 'node:path'
-import { translate, getLocale, COI2_DICT } from '../i18n.js'
+import { translate, getLocale, COI2_DICT, NOTIFY_DICT } from '../i18n.js'
+
+/** Translate through NOTIFY_DICT in the active host locale. */
+const cnt = (key, params) => translate(NOTIFY_DICT, key, params, getLocale())
 
 /** Translate through COI2_DICT in the active host locale. */
 const cix2 = (key, params) => translate(COI2_DICT, key, params, getLocale())
@@ -150,14 +153,14 @@ export function buildChannelContent(taskId, coi, status, summary) {
   const body = oneLine.slice(0, 120)
   const bar = '━━━━━━━━━━━━━━━━━━━━━━━━'
   return [
-    `cnt('coin.head', { id, name, status: status ?? '' })`,
+    `${cnt('coin.head', { id, name, status: status ?? '' })}`,
     bar,
-    `cnt('coin.subject', { id, name })`,
-    `cnt('coin.intro', { intro })`,
-    `cnt('coin.sender')`,
-    `cnt('coin.time', { time: fmtNotifyStamp() })`,
+    `${cnt('coin.subject', { id, name })}`,
+    `${cnt('coin.intro', { intro })}`,
+    `${cnt('coin.sender')}`,
+    `${cnt('coin.time', { time: fmtNotifyStamp() })}`,
     bar,
-    `cnt('coin.bodyHead')`,
+    `${cnt('coin.bodyHead')}`,
     body,
   ].join('\n')
 }

--- a/lib/coi/index.js
+++ b/lib/coi/index.js
@@ -150,14 +150,14 @@ export function buildChannelContent(taskId, coi, status, summary) {
   const body = oneLine.slice(0, 120)
   const bar = '━━━━━━━━━━━━━━━━━━━━━━━━'
   return [
-    `[COI] 任务 ${id}（${name}）${status ?? ''}`,
+    `cnt('coin.head', { id, name, status: status ?? '' })`,
     bar,
-    `📮 主题：任务完成：${id}（${name}）`,
-    `📝 简介：${intro}`,
-    `👤 发送人：DSH AI 助手（dsh-memory-evolve）`,
-    `🕐 时间：${fmtNotifyStamp()}`,
+    `cnt('coin.subject', { id, name })`,
+    `cnt('coin.intro', { intro })`,
+    `cnt('coin.sender')`,
+    `cnt('coin.time', { time: fmtNotifyStamp() })`,
     bar,
-    '📄 内容',
+    `cnt('coin.bodyHead')`,
     body,
   ].join('\n')
 }

--- a/lib/coi/scheduler.js
+++ b/lib/coi/scheduler.js
@@ -16,6 +16,10 @@ import { randomUUID } from 'node:crypto'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { buildArgs, extractSessionId } from './adapters.js'
+import { translate, getLocale, COI_DICT } from '../i18n.js'
+
+/** Translate through COI_DICT in the active host locale. */
+const cot = (key, params) => translate(COI_DICT, key, params, getLocale())
 import { resolveAttachments as resolveAttachmentsImpl } from './attachments.js'
 import { ADAPTER_STATS_FILE, adapterAvgMs as adapterAvgMsImpl, recordAdapterStats } from './stats.js'
 
@@ -155,21 +159,21 @@ export class CoiScheduler {
    * @returns {{ok:boolean, taskId?:string, status?:string, message?:string}}
    */
   dispatch(req) {
-    if (this.disposed) return { ok: false, message: '调度器已销毁' }
+    if (this.disposed) return { ok: false, message: cot('coi.disposed') }
     const adapter = this.adapters.get(req.adapterId)
-    if (!adapter) return { ok: false, message: `未知适配器 "${req.adapterId}"（可用 de_coi_adapters 查看可用适配器与适用场景）` }
+    if (!adapter) return { ok: false, message: cot('coi.adapterUnknownHint', { id: req.adapterId }) }
     if (adapter.enabled === false) {
       const available = this.adapters.list().filter((a) => a.enabled !== false).map((a) => a.id).join(' / ')
-      return { ok: false, message: `适配器 ${adapter.id}（${adapter.name}）已被禁用。可用适配器：${available}（可用 de_coi_adapters 查看适用场景）` }
+      return { ok: false, message: cot('coi.adapterDisabled', { id: adapter.id, name: adapter.name, available }) }
     }
     const prompt = String(req.prompt ?? '').trim()
-    if (!prompt) return { ok: false, message: '任务内容不能为空' }
+    if (!prompt) return { ok: false, message: cot('coi.emptyPrompt') }
     const cwd = req.cwd ?? null
     // 默认 session（仅发起会话可见）：私有默认，防止任务/注入扩散到同工作区
     // 其他会话；需要跨会话协作时显式传 project/global
     const scope = req.scope ?? 'session'
     const validScopes = ['temporary', 'session', 'project', 'global']
-    if (!validScopes.includes(scope)) return { ok: false, message: `scope 必须是 ${validScopes.join('/')}` }
+    if (!validScopes.includes(scope)) return { ok: false, message: cot('coi.badScope', { valid: validScopes.join('/') }) }
 
     // 图片附件（调用方已用 resolveAttachments 解析为本地文件数组；解析失败
     // 的请求在调用方即被拒绝，不会走到这里）。适配器不支持图片时明确报错
@@ -178,7 +182,7 @@ export class CoiScheduler {
     if (attachmentFiles.length > 0 && !adapter.image) {
       return {
         ok: false,
-        message: `适配器 ${adapter.id}（${adapter.name}）不支持图片附件。支持图片的适配器：codex（-i 参数）/ hermes（--image 参数）/ kimi（prompt 附图片路径读图）/ grok（prompt 附图片路径读图，待实测验证）；zcode 为纯文本通道不可识图`,
+        message: cot('coi.noImageSupport', { id: adapter.id, name: adapter.name }),
       }
     }
 
@@ -187,7 +191,7 @@ export class CoiScheduler {
     let finalPrompt = prompt
     if (req.refTaskId) {
       const ref = this.tasks.get(req.refTaskId)
-      if (!ref) return { ok: false, message: `引用的任务 ${req.refTaskId} 不存在` }
+      if (!ref) return { ok: false, message: cot('coi.refMissing', { id: req.refTaskId }) }
       const full = this.tasks.readLog(ref.id)
       if (full) {
         if (full.length <= RELAY_INLINE_MAX) {
@@ -323,7 +327,7 @@ export class CoiScheduler {
       ok: true,
       taskId: task.id,
       status: 'running',
-      message: `已发起 ${adapter.name} 任务 ${task.id}（scope=${scope}）`,
+      message: cot('coi.dispatched', { name: adapter.name, taskId: task.id, scope }),
     }
   }
 
@@ -626,7 +630,7 @@ export class CoiScheduler {
   cancel(taskId, opts = {}) {
     const internal = this.running.get(taskId)
     const task = this.tasks.get(taskId)
-    if (!task) return { ok: false, message: `任务 ${taskId} 不存在` }
+    if (!task) return { ok: false, message: cot('coi.taskMissing', { id: taskId }) }
     if (!internal) {
       const done = ['completed', 'failed', 'killed', 'interrupted'].includes(task.status)
       return { ok: false, message: done ? `任务 ${taskId} 已结束（${task.status}）` : `任务 ${taskId} 不在运行中` }
@@ -634,7 +638,7 @@ export class CoiScheduler {
     if (!opts.force) {
       return {
         ok: false,
-        message: `确认终止任务 ${taskId}（${task.coi}：${String(task.prompt ?? '').slice(0, 60)}）？再次调用并带 force=true 才执行`,
+        message: cot('coi.stopConfirm', { id: taskId, adapter: task.coi, preview: String(task.prompt ?? '').slice(0, 60) }),
       }
     }
     this.#kill(internal, '用户终止')
@@ -646,20 +650,20 @@ export class CoiScheduler {
     this.tasks.appendLog(taskId, `\n[任务被用户终止]\n`)
     const done = this.tasks.get(taskId)
     this.#emit('coi/task-change', snapshot(done))
-    return { ok: true, message: `任务 ${taskId} 已终止`, task: snapshot(done) }
+    return { ok: true, message: cot('coi.stopped', { id: taskId }), task: snapshot(done) }
   }
 
   /** 任务状态/详情。 */
   status(taskId) {
     const task = this.tasks.get(taskId)
-    if (!task) return { ok: false, message: `任务 ${taskId} 不存在` }
+    if (!task) return { ok: false, message: cot('coi.taskMissing', { id: taskId }) }
     return { ok: true, task: snapshot(task) }
   }
 
   /** 任务输出（留档已含全部缓冲；运行中实时读文件）。 */
   getLog(taskId, tailChars) {
     const task = this.tasks.get(taskId)
-    if (!task) return { ok: false, message: `任务 ${taskId} 不存在` }
+    if (!task) return { ok: false, message: cot('coi.taskMissing', { id: taskId }) }
     return { ok: true, text: this.tasks.readLog(taskId, tailChars) }
   }
 
@@ -681,7 +685,7 @@ export class CoiScheduler {
    */
   async wait(taskId, timeoutMs = 60000, signal) {
     const task = this.tasks.get(taskId)
-    if (!task) return { ok: false, message: `任务 ${taskId} 不存在` }
+    if (!task) return { ok: false, message: cot('coi.taskMissing', { id: taskId }) }
     if (task.status !== 'running' && task.status !== 'queued') {
       return { ok: true, task: snapshot(task) }
     }
@@ -701,7 +705,7 @@ export class CoiScheduler {
         }
         resolve(result)
       }
-      const onAbort = () => done({ ok: false, message: '等待已取消（会话已停止）' })
+      const onAbort = () => done({ ok: false, message: cot('coi.waitAborted') })
       if (signal) {
         if (signal.aborted) {
           onAbort()
@@ -712,7 +716,7 @@ export class CoiScheduler {
       const tick = () => {
         const current = this.tasks.get(taskId)
         if (!current) {
-          done({ ok: false, message: `任务 ${taskId} 不存在` })
+          done({ ok: false, message: cot('coi.taskMissing', { id: taskId }) })
           return
         }
         if (current.status !== 'running' && current.status !== 'queued') {
@@ -720,7 +724,7 @@ export class CoiScheduler {
           return
         }
         if (Date.now() >= deadline) {
-          done({ ok: false, message: `等待超时（${timeoutMs}ms），任务仍在运行，可用 de_coi_status 再查`, task: snapshot(current) })
+          done({ ok: false, message: cot('coi.waitTimeout', { timeout: timeoutMs }), task: snapshot(current) })
           return
         }
         timer = setTimeout(tick, 500)
@@ -732,7 +736,7 @@ export class CoiScheduler {
   /** 一键重试：同参数重新发起（新会话；若原任务有 sessionId 则恢复它）。 */
   retry(taskId) {
     const task = this.tasks.get(taskId)
-    if (!task) return { ok: false, message: `任务 ${taskId} 不存在` }
+    if (!task) return { ok: false, message: cot('coi.taskMissing', { id: taskId }) }
     return this.dispatch({
       adapterId: task.adapterId,
       prompt: task.prompt,
@@ -751,10 +755,10 @@ export class CoiScheduler {
   /** 适配器测试：用 testCmd 起一次性任务（不入会话库）。 */
   testAdapter(adapterId) {
     const adapter = this.adapters.get(adapterId)
-    if (!adapter) return { ok: false, message: `未知适配器 "${adapterId}"` }
-    if (adapter.enabled === false) return { ok: false, message: `适配器 ${adapterId} 已被禁用，无法测试` }
+    if (!adapter) return { ok: false, message: cot('coi.testAdapterUnknown', { id: adapterId }) }
+    if (adapter.enabled === false) return { ok: false, message: cot('coi.testAdapterDisabled', { id: adapterId }) }
     if (!Array.isArray(adapter.testCmd) || adapter.testCmd.length === 0) {
-      return { ok: false, message: `适配器 ${adapterId} 未配置 testCmd` }
+      return { ok: false, message: cot('coi.testNoCmd', { id: adapterId }) }
     }
     const task = this.tasks.add({
       adapterId: adapter.id,
@@ -787,7 +791,7 @@ export class CoiScheduler {
       })
     } catch (error) {
       this.#finish(internal, { status: 'failed', error: `启动失败: ${error.message}` })
-      return { ok: false, message: `启动失败: ${error.message}`, taskId: task.id }
+      return { ok: false, message: cot('coi.startFailed', { detail: error.message }), taskId: task.id }
     }
     internal.process = child
     try { child.stdin?.end() } catch { /* 忽略 */ }
@@ -812,7 +816,7 @@ export class CoiScheduler {
         this.#kill(internal, '适配器测试超时')
       }, timeoutMs)
     }
-    return { ok: true, taskId: task.id, message: `测试任务 ${task.id} 已启动` }
+    return { ok: true, taskId: task.id, message: cot('coi.testStarted', { id: task.id }) }
   }
 
   /**

--- a/lib/coi/session-store.js
+++ b/lib/coi/session-store.js
@@ -12,6 +12,10 @@
  */
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
+import { translate, getLocale, COI2_DICT } from '../i18n.js'
+
+/** Translate through COI2_DICT in the active host locale. */
+const cs2 = (key, params) => translate(COI2_DICT, key, params, getLocale())
 
 const SCOPES = ['temporary', 'session', 'project', 'global']
 
@@ -48,12 +52,12 @@ export class SessionStore {
    */
   upsert(rec) {
     const id = String(rec.id ?? '').trim()
-    if (!id) return { ok: false, message: 'session id 不能为空' }
+    if (!id) return { ok: false, message: cs2('coi2.sessNeedsId') }
     const scope = rec.scope ?? 'project'
     if (!SCOPES.includes(scope)) {
-      return { ok: false, message: `scope 必须是 ${SCOPES.join('/')}` }
+      return { ok: false, message: cs2('coi2.badScope', { valid: SCOPES.join('/') }) }
     }
-    if (scope === 'temporary') return { ok: false, message: '临时层级的会话不入库' }
+    if (scope === 'temporary') return { ok: false, message: cs2('coi2.temporaryNotStored') }
     const existing = this.items.find((item) => item.id === id)
     const now = Date.now()
     if (existing) {
@@ -65,7 +69,7 @@ export class SessionStore {
       existing.lastSeen = now
       if (rec.taskId) existing.lastTaskId = rec.taskId
       this.#save()
-      return { ok: true, message: '会话已更新', session: existing }
+      return { ok: true, message: cs2('coi2.sessUpdated'), session: existing }
     }
     const session = {
       id,
@@ -83,7 +87,7 @@ export class SessionStore {
     }
     this.items.push(session)
     this.#save()
-    return { ok: true, message: '会话已登记', session }
+    return { ok: true, message: cs2('coi2.sessRegistered'), session }
   }
 
   /**
@@ -138,19 +142,19 @@ export class SessionStore {
   /** 设置/清除备注。 */
   updateNote(id, note) {
     const session = this.findById(id)
-    if (!session) return { ok: false, message: `会话 ${id} 不存在` }
+    if (!session) return { ok: false, message: cs2('coi2.sessMissing', { id }) }
     session.note = String(note ?? '').trim() || null
     this.#save()
-    return { ok: true, message: '备注已更新', session }
+    return { ok: true, message: cs2('coi2.noteUpdated'), session }
   }
 
   /** 删除一条会话记录。 */
   remove(id) {
     const index = this.items.findIndex((item) => item.id === id)
-    if (index < 0) return { ok: false, message: `会话 ${id} 不存在` }
+    if (index < 0) return { ok: false, message: cs2('coi2.sessMissing', { id }) }
     const [removed] = this.items.splice(index, 1)
     this.#save()
-    return { ok: true, message: `已删除会话 ${id}`, session: removed }
+    return { ok: true, message: cs2('coi2.sessDeleted', { id }), session: removed }
   }
 
   /**
@@ -161,16 +165,16 @@ export class SessionStore {
    */
   acquire(id, taskId) {
     const session = this.findById(id)
-    if (!session) return { ok: false, message: `会话 ${id} 未登记` }
+    if (!session) return { ok: false, message: cs2('coi2.sessNotRegistered', { id }) }
     if (session.activeTaskId && session.activeTaskId !== taskId) {
       return {
         ok: false,
-        message: `会话 ${id} 正被任务 ${session.activeTaskId} 占用（同一会话不能并发跑多个任务）`,
+        message: cs2('coi2.sessBusy', { id, task: session.activeTaskId }),
       }
     }
     session.activeTaskId = taskId
     this.#save()
-    return { ok: true, message: '会话已锁定' }
+    return { ok: true, message: cs2('coi2.sessLocked') }
   }
 
   /** 释放会话锁（任务结束/取消时调用）。 */

--- a/lib/coi/tasks-store.js
+++ b/lib/coi/tasks-store.js
@@ -8,6 +8,10 @@
  */
 import { appendFileSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { translate, getLocale, COI2_DICT } from '../i18n.js'
+
+/** Translate through COI2_DICT in the active host locale. */
+const ctk2 = (key, params) => translate(COI2_DICT, key, params, getLocale())
 
 let sequence = 0
 /** 生成任务 id：coi-<时间戳>-<序号>。 */
@@ -169,15 +173,15 @@ export class TaskStore {
    */
   remove(id) {
     const task = this.tasks.find((t) => t.id === id)
-    if (!task) return { ok: false, message: `任务 ${id} 不存在` }
+    if (!task) return { ok: false, message: ctk2('coi2.taskMissing', { id }) }
     if (task.status === 'running' || task.status === 'queued') {
-      return { ok: false, message: `任务 ${id} 正在运行，请先终止再删除` }
+      return { ok: false, message: ctk2('coi2.taskRunningDelete', { id }) }
     }
     const index = this.tasks.indexOf(task)
     this.tasks.splice(index, 1)
     this.#save()
     try { rmSync(this.logPath(id), { force: true }) } catch { /* 忽略 */ }
-    return { ok: true, message: `已删除任务 ${id}` }
+    return { ok: true, message: ctk2('coi2.taskDeleted', { id }) }
   }
 
   /** 输出留档路径。 */

--- a/lib/coi/templates.js
+++ b/lib/coi/templates.js
@@ -4,8 +4,10 @@
  */
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
+import { translate, getLocale, COI_DICT } from '../i18n.js'
 
-/** 内置默认模板（用户可覆盖同 id）。 */
+/** 内置默认模板（用户可覆盖同 id）。name 是显示名的 zh 源；list() 按活跃
+ * 语言本地化（custom 覆盖与用户自建模板原样保留）。 */
 export const BUILTIN_TEMPLATES = [
   { id: 'review-code', name: 'Review 代码', adapterId: 'kimi', prompt: '请 review 当前项目的代码，列出最需要修复的三个问题（附理由与修复建议），并输出简要报告。' },
   { id: 'fix-tests', name: '修复测试', adapterId: 'codex', prompt: '运行项目测试，定位失败原因，给出最小修复方案并实施，最后运行测试验证。' },
@@ -43,7 +45,12 @@ export class TemplateStore {
   }
 
   list() {
-    return [...this.byId.values()]
+    const locale = getLocale()
+    return [...this.byId.values()].map((tpl) => (
+      this.custom[tpl.id] === undefined && tpl.name === BUILTIN_TEMPLATES.find((b) => b.id === tpl.id)?.name
+        ? { ...tpl, name: translate(COI_DICT, `coi.template.name.${tpl.id}`, undefined, locale) }
+        : tpl
+    ))
   }
 
   get(id) {

--- a/lib/coi/tools.js
+++ b/lib/coi/tools.js
@@ -12,6 +12,10 @@
  *   - 跨 COI 接力：传 refTaskId 引用上一任务的输出
  */
 import { existsSync } from 'node:fs'
+import { translate, getLocale, COI2_DICT } from '../i18n.js'
+
+/** Translate through COI2_DICT in the active host locale. */
+const ctl2 = (key, params) => translate(COI2_DICT, key, params, getLocale())
 
 const SCOPE_ENUM = ['temporary', 'session', 'project', 'global']
 
@@ -168,10 +172,10 @@ export function coiToolDefinitions(scheduler) {
           prompt = template.prompt
           if (!args.adapterId && template.adapterId) args = { ...args, adapterId: template.adapterId }
         } else {
-          return { ok: false, message: `模板 ${templateId} 不存在` }
+          return { ok: false, message: ctl2('coi2.templateMissing', { id: templateId }) }
         }
       }
-      if (!prompt) return { ok: false, message: '任务内容不能为空（或指定 templateId）' }
+      if (!prompt) return { ok: false, message: ctl2('coi2.emptyPromptTemplate') }
       const agentCwd = exec?.agent?.session?.header?.cwd
       const cwd = args.cwd ?? agentCwd ?? null
       // 图片附件：先异步解析（path 校验 / url 下载 / attachmentId 会话引用
@@ -245,7 +249,7 @@ export function coiToolDefinitions(scheduler) {
       // 任务不存在：{ ok:false, message } 已符合 schema，直接返回
       if (result.task === undefined) return result
       const task = statusTaskView(result.task)
-      return { ok: true, message: `任务 ${task.id}（${task.coi || task.adapterId}）：${task.status}`, task }
+      return { ok: true, message: ctl2('coi2.taskStatus', { id: task.id, adapter: task.coi || task.adapterId, status: task.status }), task }
     },
   }
 
@@ -279,7 +283,7 @@ export function coiToolDefinitions(scheduler) {
         const logHint = existsSync(logPath)
           ? `📄 完整日志：${logPath}（输出为尾部摘要；需要完整输出请用 read 工具读取该文件，不要自行搜索）`
           : `📄 完整日志：${logPath}（暂无输出文件）`
-        return [{ type: 'text', text: `${logHint}\n任务 ${task.id}：${task.status}\n${task.summary ? `输出摘要：\n${task.summary}` : ''}` }]
+        return [{ type: 'text', text: ctl2('coi2.taskLog', { logHint, id: task.id, status: task.status, summary: task.summary ? ctl2('coi2.taskSummaryHead', { summary: task.summary }) : '' }) }]
       },
     },
     async execute(args, exec) {
@@ -288,7 +292,7 @@ export function coiToolDefinitions(scheduler) {
       // scheduler.wait：abort 时 wait 立即停止内部轮询并 resolve。
       // 原来用 Promise.race 取消时 wait 的 Promise 永不 settle，内部
       // 500ms 轮询链会空转到 deadline（定时器链泄漏，P0-1）。
-      if (exec?.signal?.aborted) return { ok: false, message: '等待已取消（会话已停止）' }
+      if (exec?.signal?.aborted) return { ok: false, message: ctl2('coi2.waitAborted') }
       const result = await scheduler.wait(args.taskId, timeoutMs, exec?.signal)
       // 任务不存在 / 被取消：{ ok:false, message } 已符合 schema
       if (result.task === undefined) return result

--- a/lib/coi/ws-coord.js
+++ b/lib/coi/ws-coord.js
@@ -38,6 +38,10 @@
 import { randomUUID } from 'node:crypto'
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve as pathResolve } from 'node:path'
+import { translate, getLocale, COI2_DICT } from '../i18n.js'
+
+/** Translate through COI2_DICT in the active host locale. */
+const cw2 = (key, params) => translate(COI2_DICT, key, params, getLocale())
 
 /** 写盘防抖间隔（ms）：fs/observed 高频，没必要每次事件都写盘。 */
 const SAVE_DEBOUNCE_MS = 1500
@@ -521,13 +525,13 @@ export function wsToolDefinitions(store, displayName, sessionMeta, archivedIds =
       },
       async execute(args, exec) {
         const ctx = ctxOf(exec)
-        if (!ctx) return { ok: false, message: '无法识别调用会话（非 agent 上下文），不执行登记' }
+        if (!ctx) return { ok: false, message: cw2('coi2.wsNoCtxDeclare') }
         try {
           const { declared, conflicts } = store.declare({ sessionId: ctx.sessionId, cwd: ctx.cwd, targets: args.targets, services: args.services, ttlSeconds: args.ttlSeconds })
           const msg = declared.length === 0 ? '没有可登记的目标（targets/services 均为空或不合法）' : `已登记 ${declared.length} 项占用${conflicts.length > 0 ? `，检测到 ${conflicts.length} 项与其他会话冲突` : ''}`
           return { ok: true, message: msg, declared: declared.map(lockView), conflicts: conflicts.map(lockView) }
         } catch (error) {
-          return { ok: false, message: `声明失败：${errText(error)}`, declared: [], conflicts: [] }
+          return { ok: false, message: cw2('coi2.declareFailed', { detail: errText(error) }), declared: [], conflicts: [] }
         }
       },
     },
@@ -601,13 +605,13 @@ export function wsToolDefinitions(store, displayName, sessionMeta, archivedIds =
           const active = store.activeFor(ctx?.cwd, sessionMeta ?? new Map(), Date.now(), archivedIds)
           return {
             ok: true,
-            message: `查询完成：${locks.length} 项占用，${active.length} 个活跃会话`,
+            message: cw2('coi2.queryDone', { locks: locks.length, active: active.length }),
             locks: locks.map(lockView),
             active: active.map((a) => ({ sessionId: a.sessionId, display: displayName(a.sessionId), status: a.status, note: a.note, lockCount: a.lockCount, since: a.since })),
             _self: ctx?.sessionId ?? '',
           }
         } catch (error) {
-          return { ok: false, message: `查询失败：${errText(error)}`, locks: [], active: [], _self: ctx?.sessionId ?? '' }
+          return { ok: false, message: cw2('coi2.queryFailed', { detail: errText(error) }), locks: [], active: [], _self: ctx?.sessionId ?? '' }
         }
       },
     },
@@ -655,12 +659,12 @@ export function wsToolDefinitions(store, displayName, sessionMeta, archivedIds =
       },
       async execute(args, exec) {
         const ctx = ctxOf(exec)
-        if (!ctx) return { ok: false, message: '无法识别调用会话（非 agent 上下文），不执行释放', released: [], remaining: 0 }
+        if (!ctx) return { ok: false, message: cw2('coi2.wsNoCtxRelease'), released: [], remaining: 0 }
         try {
           const { released, remaining } = store.release({ sessionId: ctx.sessionId, paths: args.paths, all: args.all === true })
-          return { ok: true, message: `已释放 ${released.length} 项占用`, released: released.map(lockView), remaining }
+          return { ok: true, message: cw2('coi2.released', { count: released.length }), released: released.map(lockView), remaining }
         } catch (error) {
-          return { ok: false, message: `释放失败：${errText(error)}`, released: [], remaining: 0 }
+          return { ok: false, message: cw2('coi2.releaseFailed', { detail: errText(error) }), released: [], remaining: 0 }
         }
       },
     },

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -43,6 +43,11 @@ export const LOCALES = ['zh', 'en']
  * @returns {'zh'|'en'} the resolved locale id.
  */
 export function resolveLocale(ctx) {
+  // Child-process override (spawnWorker passes the host locale down so the
+  // memory-sync worker speaks the same language as its parent).
+  const fromEnv = typeof process !== 'undefined' && process.env?.DSH_LOCALE
+  if (fromEnv === 'zh') return 'zh'
+  if (fromEnv === 'en') return 'en'
   try {
     const settings = ctx?.get?.('settings')
     if (!settings || typeof settings.get !== 'function') return 'en'
@@ -52,6 +57,11 @@ export function resolveLocale(ctx) {
   } catch {
     return 'en'
   }
+}
+
+/** The module-level active locale (for passing to child processes). */
+export function getActiveLocale() {
+  return active
 }
 
 /**
@@ -924,4 +934,331 @@ export const MISC2_DICT = {
   'upd.notGitRepo': ['插件目录不是 git 仓库或 git 不可用（请用 git clone 安装）', 'The plugin directory is not a git repo or git is unavailable (install via git clone)'],
   'upd.remoteCheckFailed': ['远端检测失败（{kind}）', 'Remote check failed ({kind})'],
   'notify.missing': ['通知 {id} 不存在', 'Notification {id} does not exist'],
+}
+
+/** COI broadcast messages (lib/coi/broadcast.js). */
+export const BROADCAST_DICT = {
+  'bc.attachLimit': ['图片附件数量超限：最多 {max} 张（收到 {count} 张）', 'Too many image attachments: at most {max} (got {count})'],
+  'bc.needsCreator': ['创建者会话 id 不能为空', 'Creator session id must not be empty'],
+  'bc.roomCreated': ['房间「{name}」已创建（你是成员；告诉其他人房间 id {id} 让它们 room-join）', 'Room "{name}" created (you are a member; share room id {id} so others can room-join)'],
+  'bc.roomMissingJoin': ['房间 {id} 不存在（请向创建者确认房间 id）', 'Room {id} does not exist (confirm the room id with its creator)'],
+  'bc.roomDissolved': ['房间「{name}」已解散，无法加入', 'Room "{name}" was dissolved; cannot join'],
+  'bc.joined': ['已加入房间「{name}」（成员 {count} 人）', 'Joined room "{name}" ({count} member(s))'],
+  'bc.roomMissing': ['房间 {id} 不存在', 'Room {id} does not exist'],
+  'bc.leftAutoDissolved': ['已退出，房间 {id} 无成员已解散（记录保留可追溯）', 'Left; room {id} had no members and was dissolved (records kept for traceability)'],
+  'bc.left': ['已退出房间「{name}」（剩 {count} 人）', 'Left room "{name}" ({count} member(s) remain)'],
+  'bc.onlyCreatorDissolve': ['只有创建者可以解散房间', 'Only the creator can dissolve the room'],
+  'bc.alreadyDissolved': ['房间「{name}」已是解散状态', 'Room "{name}" is already dissolved'],
+  'bc.dissolved': ['房间「{name}」已解散', 'Room "{name}" dissolved'],
+  'bc.memberNotInRoom': ['成员 {member} 不在房间中', 'Member {member} is not in the room'],
+  'bc.kickedAutoDissolved': ['已踢出 {member}，房间无成员已解散', 'Kicked {member}; the room has no members and was dissolved'],
+  'bc.kicked': ['已踢出成员 {member}（剩 {count} 人）', 'Member {member} kicked ({count} member(s) remain)'],
+  'bc.needsSender': ['发送方会话 id 不能为空', 'Sender session id must not be empty'],
+  'bc.badRecipients': ['recipients 必须是非空数组（会话 ID 或 room:/project: 伪接收者）', 'recipients must be a non-empty array (session IDs or room:/project: pseudo-recipients)'],
+  'bc.sendRoomMissing': ['房间 {id} 不存在（先 room-create，或向创建者确认房间 id 后 room-join）', 'Room {id} does not exist (room-create first, or confirm the id with the creator and room-join)'],
+  'bc.sendRoomDissolved': ['房间「{name}」已解散，无法发消息', 'Room "{name}" was dissolved; cannot send messages'],
+  'bc.notMember': ['你不是房间「{name}」的成员（先 room-join 加入）', 'You are not a member of room "{name}" (room-join first)'],
+  'bc.projectNeedsPath': ['project: 后必须跟工作目录绝对路径，如 project:/Volumes/data/proj', 'project: must be followed by an absolute working-directory path, e.g. project:/Volumes/data/proj'],
+  'bc.emptyContent': ['消息内容不能为空', 'Message content must not be empty'],
+  'bc.sent': ['广播已发送（{count} 个接收目标{tail}）', 'Broadcast sent ({count} recipient(s){tail})'],
+  'bc.sentImages': ['，图片 {count} 张', ', {count} image(s)'],
+  'bc.msgMissing': ['消息 {id} 不存在', 'Message {id} does not exist'],
+  'bc.msgInvisible': ['该消息对当前会话不可见，无法读取', 'This message is not visible to the current session and cannot be read'],
+  'bc.msgDetail': ['消息 {id}（{sender} → {recipients}）', 'Message {id} ({sender} → {recipients})'],
+  'bc.onlySenderOrRecipient': ['只有发送方或接收方可删除该消息', 'Only the sender or a recipient can delete this message'],
+  'bc.deleted': ['已删除消息 {id}', 'Message {id} deleted'],
+  'bc.imagesDisabled': ['图片附件未启用（配置项 broadcastImageEnabled=false；开启后才能带图发送）', 'Image attachments are disabled (config broadcastImageEnabled=false; enable it to send images)'],
+  'bc.attachFailed': ['附件处理失败：{detail}', 'Attachment processing failed: {detail}'],
+  'bc.listHead': ['消息（{label} {count} 条）', 'Messages ({label}: {count})'],
+  'bc.readNeedsIds': ['read 必填 id 或 ids（消息 id）', 'read needs id or ids (message ids)'],
+  'bc.readDone': ['已读取 {count} 条{tail}', '{count} message(s) read{tail}'],
+  'bc.readSkipped': ['，跳过 {count} 条（不可见/不存在）', ', skipped {count} (invisible/missing)'],
+  'bc.kickRoomMissing': ['房间 {id} 不存在', 'Room {id} does not exist'],
+  'bc.onlyCreatorKick': ['只有创建者可以踢人', 'Only the creator can kick members'],
+  'bc.presenceDisabled': ['在线状态追踪未启用', 'Presence tracking is not enabled'],
+  'bc.presenceOne': ['会话 {sid} 状态', 'Session {sid} presence'],
+  'bc.presenceList': ['房间「{name}」成员在线状态（{online}/{total} 在线）', 'Room "{name}" member presence ({online}/{total} online)'],
+  'bc.unknownAction': ['未知 action "{action}"', 'Unknown action "{action}"'],
+}
+
+/** COI scheduler + command messages (lib/coi/scheduler.js, lib/coi/commands.js). */
+export const COI_DICT = {
+  'coi.disposed': ['调度器已销毁', 'The scheduler has been disposed'],
+  'coi.adapterUnknownHint': ['未知适配器 "{id}"（可用 de_coi_adapters 查看可用适配器与适用场景）', 'Unknown adapter "{id}" (run de_coi_adapters to list adapters and their use cases)'],
+  'coi.adapterDisabled': ['适配器 {id}（{name}）已被禁用。可用适配器：{available}（可用 de_coi_adapters 查看适用场景）', 'Adapter {id} ({name}) is disabled. Available adapters: {available} (see de_coi_adapters for use cases)'],
+  'coi.emptyPrompt': ['任务内容不能为空', 'Task prompt must not be empty'],
+  'coi.badScope': ['scope 必须是 {valid}', 'scope must be one of {valid}'],
+  'coi.noImageSupport': [
+    '适配器 {id}（{name}）不支持图片附件。支持图片的适配器：codex（-i 参数）/ hermes（--image 参数）/ kimi（prompt 附图片路径读图）/ grok（prompt 附图片路径读图，待实测验证）；zcode 为纯文本通道不可识图',
+    'Adapter {id} ({name}) does not support image attachments. Image-capable adapters: codex (-i flag) / hermes (--image flag) / kimi (attach the image path in the prompt) / grok (same as kimi; unverified); zcode is text-only and cannot read images',
+  ],
+  'coi.refMissing': ['引用的任务 {id} 不存在', 'Referenced task {id} does not exist'],
+  'coi.dispatched': ['已发起 {name} 任务 {taskId}（scope={scope}）', 'Dispatched {name} task {taskId} (scope={scope})'],
+  'coi.taskMissing': ['任务 {id} 不存在', 'Task {id} does not exist'],
+  'coi.stopConfirm': ['确认终止任务 {id}（{adapter}：{preview}）？再次调用并带 force=true 才执行', 'Confirm stopping task {id} ({adapter}: {preview})? Call again with force=true to proceed'],
+  'coi.stopped': ['任务 {id} 已终止', 'Task {id} stopped'],
+  'coi.waitAborted': ['等待已取消（会话已停止）', 'Wait cancelled (the session was stopped)'],
+  'coi.waitTimeout': ['等待超时（{timeout}ms），任务仍在运行，可用 de_coi_status 再查', 'Wait timed out after {timeout}ms; the task is still running — check again with de_coi_status'],
+  'coi.testAdapterUnknown': ['未知适配器 "{id}"', 'Unknown adapter "{id}"'],
+  'coi.testAdapterDisabled': ['适配器 {id} 已被禁用，无法测试', 'Adapter {id} is disabled and cannot be tested'],
+  'coi.testNoCmd': ['适配器 {id} 未配置 testCmd', 'Adapter {id} has no testCmd configured'],
+  'coi.startFailed': ['启动失败: {detail}', 'Start failed: {detail}'],
+  'coi.testStarted': ['测试任务 {id} 已启动', 'Test task {id} started'],
+  'coicmd.runUsage': ['用法：/de_coi run "<任务>" [--coi kimi] [--scope session] [--session <id>] [--branch <b>] [--model <m>] [--ref <taskId>] [--template <id>] [--continue] [--inject-tracks memory,user,key] [--context-text <文本>]', 'Usage: /de_coi run "<task>" [--coi kimi] [--scope session] [--session <id>] [--branch <b>] [--model <m>] [--ref <taskId>] [--template <id>] [--continue] [--inject-tracks memory,user,key] [--context-text <text>]'],
+  'coicmd.dispatched': ['✅ {message}\n查看进度：/de_coi log {taskId}', '✅ {message}\nTrack progress: /de_coi log {taskId}'],
+  'coicmd.noTasks': ['（暂无任务）', '(no tasks yet)'],
+  'coicmd.taskList': ['任务（{count} 条）：\n{lines}', 'Tasks ({count}):\n{lines}'],
+  'coicmd.logUsage': ['用法：/de_coi log <taskId> [--tail <字符数>]', 'Usage: /de_coi log <taskId> [--tail <chars>]'],
+  'coicmd.stopUsage': ['用法：/de_coi stop <taskId> [--force]（终止需二次确认；--all 需同时带 --force）', 'Usage: /de_coi stop <taskId> [--force] (stopping needs a second confirmation; --all additionally requires --force)'],
+  'coicmd.stopAllConfirm': ['⚠️ 终止全部任务需二次确认：/de_coi stop --all --force', '⚠️ Stopping every task needs a second confirmation: /de_coi stop --all --force'],
+  'coicmd.stoppedMany': ['已终止 {count} 个任务', '{count} task(s) stopped'],
+  'coicmd.stopOneConfirm': ['⚠️ 确认终止任务 {id}（{adapter}：{preview}）？确认请再次执行：/de_coi stop {id} --force', '⚠️ Confirm stopping task {id} ({adapter}: {preview})? Run /de_coi stop {id} --force again to confirm'],
+  'coicmd.noSessions': ['（暂无会话记录）', '(no session records yet)'],
+  'coicmd.sessionList': ['会话（{count} 条）：\n{lines}', 'Sessions ({count}):\n{lines}'],
+  'coicmd.noteUsage': ['用法：/de_coi sessions note <sessionId> <备注>', 'Usage: /de_coi sessions note <sessionId> <note>'],
+  'coicmd.rmUsage': ['用法：/de_coi sessions rm <sessionId>', 'Usage: /de_coi sessions rm <sessionId>'],
+  'coicmd.sessionsSubs': ['sessions 子命令：list / note <id> <备注> / rm <id>', 'sessions subcommands: list / note <id> <note> / rm <id>'],
+  'coicmd.adapterUnknown': ['未知适配器 {id}', 'Unknown adapter {id}'],
+  'coicmd.adapterShow': ['{id} — {name}\n类型：{type}\n命令：{cmd}\n{guide}', '{id} — {name}\nType: {type}\nCommand: {cmd}\n{guide}'],
+  'coicmd.adapterGuide': ['指南：\n{guide}', 'Guide:\n{guide}'],
+  'coicmd.adaptersSubs': ['adapters 子命令：list / show <id> / test <id> / enable <id> / disable <id>', 'adapters subcommands: list / show <id> / test <id> / enable <id> / disable <id>'],
+  'coicmd.templatesSubs': ['templates 子命令：list', 'templates subcommands: list'],
+  'coicmd.exportUsage': ['用法：/de_coi export <sessionId> [--coi kimi]', 'Usage: /de_coi export <sessionId> [--coi kimi]'],
+  'coicmd.exportUnsupported': ['适配器 {id} 不支持会话导出', 'Adapter {id} does not support session export'],
+  'coicmd.exportStarted': ['导出任务已启动（{cmd}），完成后输出在 {outFile}', 'Export task started ({cmd}); output will land in {outFile}'],
+}
+export const HELP_EXTRA = {
+  'coicmd.help': [
+    `de_coi — COI 调度命令族
+  /de_coi run "<任务>" [--coi kimi|codex|grok|hermes] [--scope temporary|session|project|global] [--session <id>] [--branch <b>] [--model <m>] [--ref <taskId>] [--template <id>] [--continue] [--inject-context] [--context-text <文本>]
+  /de_coi list [--coi <id>] [--status <s>] [--limit <n>] [--q <关键词>]
+  /de_coi log <taskId> [--tail <字符数>]
+  /de_coi stop <taskId> [--force]（终止需二次确认；--all 需 --force --all）
+  /de_coi sessions [list|note <id> <备注>|rm <id>] [--scope] [--branch] [--q]
+  /de_coi adapters [list|show <id>|test <id>|enable <id>|disable <id>]
+  /de_coi stats
+  /de_coi templates list
+  /de_coi export <sessionId> [--coi <id>]`,
+    `de_coi — COI dispatch command family
+  /de_coi run "<task>" [--coi kimi|codex|grok|hermes] [--scope temporary|session|project|global] [--session <id>] [--branch <b>] [--model <m>] [--ref <taskId>] [--template <id>] [--continue] [--inject-context] [--context-text <text>]
+  /de_coi list [--coi <id>] [--status <s>] [--limit <n>] [--q <keyword>]
+  /de_coi log <taskId> [--tail <chars>]
+  /de_coi stop <taskId> [--force] (stopping needs a second confirmation; --all requires --force --all)
+  /de_coi sessions [list|note <id> <note>|rm <id>] [--scope] [--branch] [--q]
+  /de_coi adapters [list|show <id>|test <id>|enable <id>|disable <id>]
+  /de_coi stats
+  /de_coi templates list
+  /de_coi export <sessionId> [--coi <id>]`,
+  ],
+}
+
+/** COI adapters/api/index/session/tasks/tools/ws-coord messages. */
+export const COI2_DICT = {
+  'coi2.adapterUnknown': ['未知适配器 "{id}"', 'Unknown adapter "{id}"'],
+  'coi2.enabledMustBeBool': ['enabled 必须是布尔值', 'enabled must be a boolean'],
+  'coi2.adapterToggled': ['{name} 已{state}', '{name} {state}'],
+  'coi2.stateOn': ['启用', 'enabled'],
+  'coi2.stateOff': ['禁用', 'disabled'],
+  'coi2.builtinUndeletable': ['内置适配器不可删除', 'Built-in adapters cannot be deleted'],
+  'coi2.skillIoUnavailable': ['技能读写不可用', 'Skill read/write is unavailable'],
+  'coi2.skillExistsUnchanged': ['技能 {skill} 已存在，内容未改动（可在适配器页「技能」按钮编辑）', 'Skill {skill} already exists; content unchanged (edit it via the "Skill" button on the adapter page)'],
+  'coi2.skillAutoCreated': ['技能 {skill} 已自动创建（AI 可见，技能管理 Tab 可禁用）', 'Skill {skill} created automatically (visible to AI; disable it from the Skill Management tab)'],
+  'coi2.skillCreateFailed': ['技能创建失败：{detail}', 'Creating the skill failed: {detail}'],
+  'coi2.sessionIdEmpty': ['sessionId 不能为空', 'sessionId must not be empty'],
+  'coi2.exportUnsupportedApi': ['适配器 {id} 不支持会话导出', 'Adapter {id} does not support session export'],
+  'coi2.exportStartedApi': ['导出任务已启动，输出将写入 {outFile}', 'Export task started; output will be written to {outFile}'],
+  'coi2.unknownRoute': ['未知路由 {path}', 'Unknown route {path}'],
+  'coi2.attachMustBeArray': ['attachments 必须是数组', 'attachments must be an array'],
+  'coi2.attachLimit': ['图片附件最多 {max} 张（收到 {count} 张）', 'At most {max} image attachments (got {count})'],
+  'coi2.attachNotObject': ['第 {n} 个附件必须是对象', 'Attachment #{n} must be an object'],
+  'coi2.attachKindUnsupported': ['第 {n} 个附件类型 "{kind}" 暂不支持（当前仅支持图片 image）', 'Attachment #{n}: kind "{kind}" is not supported yet (only images are supported)'],
+  'coi2.attachNoSource': ['第 {n} 个附件缺少来源（path / url / attachmentId 三选一）', 'Attachment #{n} has no source (one of path / url / attachmentId)'],
+  'coi2.attachMultiSource': ['第 {n} 个附件来源只能三选一（path / url / attachmentId）', 'Attachment #{n}: pick exactly one source (path / url / attachmentId)'],
+  'coi2.attachFileMissing': ['第 {n} 个附件本地文件不存在：{path}', 'Attachment #{n}: local file does not exist: {path}'],
+  'coi2.attachNotImage': ['第 {n} 个附件不是图片文件（仅支持 png/jpg/jpeg/webp/gif）：{path}', 'Attachment #{n} is not an image file (png/jpg/jpeg/webp/gif only): {path}'],
+  'coi2.attachBadUrl': ['第 {n} 个附件 url 必须是 http(s) 地址', 'Attachment #{n}: url must be an http(s) address'],
+  'coi2.attachDownloadHttpFail': ['第 {n} 个附件下载失败（HTTP {status}）：{url}', 'Attachment #{n}: download failed (HTTP {status}): {url}'],
+  'coi2.attachDownloadFail': ['第 {n} 个附件下载失败：{detail}', 'Attachment #{n}: download failed: {detail}'],
+  'coi2.attachSessionNeedsRuntime': [
+    '第 {n} 个附件引用会话图片需要 DSH 新快照运行时的 attachments 服务（当前进程不支持），请改用 path/url 来源，或重启 DSH 后重试',
+    'Attachment #{n}: session-image references need the attachments service from a newer DSH snapshot (this process lacks it); use a path/url source instead, or restart DSH and retry',
+  ],
+  'coi2.attachSessionNotFound': [
+    '第 {n} 个附件在发起会话中未找到匹配的图片（attachmentId={id}）——图片须来自当前会话消息（浏览器输入框贴图）',
+    'Attachment #{n}: no matching image in the originating session (attachmentId={id}) — the image must come from a message in the current session (pasted in the browser input box)',
+  ],
+  'coi2.attachSessionReadFail': ['第 {n} 个附件读取会话图片失败：{detail}', 'Attachment #{n}: reading the session image failed: {detail}'],
+  'coi2.attachSessionNoData': ['第 {n} 个附件读取会话图片失败：未返回数据', 'Attachment #{n}: reading the session image failed (no data returned)'],
+  'coi2.attMissingInMsg': ['附件不存在（消息 {id} 第 {index} 张）', 'Attachment not found (message {id}, image #{index})'],
+  'coi2.attFileMissing': ['附件文件缺失（{name}）', 'Attachment file missing ({name})'],
+  'coi2.msgMissing': ['消息 {id} 不存在', 'Message {id} does not exist'],
+  'coi2.roomMissing': ['房间 {id} 不存在', 'Room {id} does not exist'],
+  'coi2.unknownRouteB': ['未知路由 {path}', 'Unknown route {path}'],
+  'coi2.adapterNoSkill': ['适配器 {id} 未关联技能', 'Adapter {id} has no skill associated'],
+  'coi2.skillReadFailed': ['读取技能失败: {detail}', 'Reading the skill failed: {detail}'],
+  'coi2.skillSaved': ['技能 {skill} 已保存（源头为插件内置，重启时版本未变不会覆盖你的编辑）', 'Skill {skill} saved (it originates from the plugin; on restart an unchanged version will not overwrite your edit)'],
+  'coi2.skillSaveFailed': ['保存技能失败: {detail}', 'Saving the skill failed: {detail}'],
+  'coi2.sessNeedsId': ['session id 不能为空', 'session id must not be empty'],
+  'coi2.badScope': ['scope 必须是 {valid}', 'scope must be one of {valid}'],
+  'coi2.temporaryNotStored': ['临时层级的会话不入库', 'Temporary-scope sessions are not persisted'],
+  'coi2.sessUpdated': ['会话已更新', 'Session updated'],
+  'coi2.sessRegistered': ['会话已登记', 'Session registered'],
+  'coi2.sessMissing': ['会话 {id} 不存在', 'Session {id} does not exist'],
+  'coi2.noteUpdated': ['备注已更新', 'Note updated'],
+  'coi2.sessDeleted': ['已删除会话 {id}', 'Session {id} deleted'],
+  'coi2.sessNotRegistered': ['会话 {id} 未登记', 'Session {id} is not registered'],
+  'coi2.sessBusy': ['会话 {id} 正被任务 {task} 占用（同一会话不能并发跑多个任务）', 'Session {id} is occupied by task {task} (a session cannot run multiple tasks concurrently)'],
+  'coi2.sessLocked': ['会话已锁定', 'Session locked'],
+  'coi2.taskMissing': ['任务 {id} 不存在', 'Task {id} does not exist'],
+  'coi2.taskRunningDelete': ['任务 {id} 正在运行，请先终止再删除', 'Task {id} is running — stop it before deleting'],
+  'coi2.taskDeleted': ['已删除任务 {id}', 'Task {id} deleted'],
+  'coi2.templateMissing': ['模板 {id} 不存在', 'Template {id} does not exist'],
+  'coi2.emptyPromptTemplate': ['任务内容不能为空（或指定 templateId）', 'Task prompt must not be empty (or pass templateId)'],
+  'coi2.taskStatus': ['任务 {id}（{adapter}）：{status}', 'Task {id} ({adapter}): {status}'],
+  'coi2.taskLog': ['{logHint}\n任务 {id}：{status}\n{summary}', '{logHint}\nTask {id}: {status}\n{summary}'],
+  'coi2.taskSummaryHead': ['输出摘要：\n{summary}', 'Output summary:\n{summary}'],
+  'coi2.waitAborted': ['等待已取消（会话已停止）', 'Wait cancelled (the session was stopped)'],
+  'coi2.wsNoCtxDeclare': ['无法识别调用会话（非 agent 上下文），不执行登记', 'Cannot identify the calling session (not an agent context); skipping declaration'],
+  'coi2.declareFailed': ['声明失败：{detail}', 'Declaration failed: {detail}'],
+  'coi2.queryDone': ['查询完成：{locks} 项占用，{active} 个活跃会话', 'Query complete: {locks} lock(s) held, {active} active session(s)'],
+  'coi2.queryFailed': ['查询失败：{detail}', 'Query failed: {detail}'],
+  'coi2.wsNoCtxRelease': ['无法识别调用会话（非 agent 上下文），不执行释放', 'Cannot identify the calling session (not an agent context); skipping release'],
+  'coi2.released': ['已释放 {count} 项占用', '{count} lock(s) released'],
+  'coi2.releaseFailed': ['释放失败：{detail}', 'Release failed: {detail}'],
+}
+
+/** Memory-sync messages (lib/sync/index.js). */
+export const SYNC_DICT = {
+  'sync.workerNoOutput': ['worker 无输出{tail}', 'The worker produced no output{tail}'],
+  'sync.workerParen': ['（{detail}）', ' ({detail})'],
+  'sync.workerUnparseable': ['worker 输出无法解析：{line}', 'Worker output could not be parsed: {line}'],
+  'sync.projectOn': ['本项目已启用同步', 'Sync is enabled for this project'],
+  'sync.projectOff': ['本项目已停用同步（记忆完整保留，可随时重新启用）', 'Sync is disabled for this project (memory fully retained; re-enable any time)'],
+  'sync.notInitialized': ['项目尚未初始化——先启用本项目同步', 'The project is not initialized — enable sync for this project first'],
+  'sync.badGlobalTrack': ['未知全局轨 "{track}"（应为 memory/user/daily/todo）', 'Unknown global track "{track}" (expected memory/user/daily/todo)'],
+  'sync.globalToggled': ['全局{track}同步已{state}', 'Global {track} sync {state}'],
+  'sync.stateOn': ['开启', 'enabled'],
+  'sync.stateOff': ['关闭', 'disabled'],
+  'sync.globalRepoMissing': ['全局记忆仓库尚未初始化——先在下方填共享记忆仓库地址初始化', 'The global memory repo is not initialized — fill in the shared-memory repo URL below first'],
+  'sync.noGlobalTracks': ['未开启任何全局轨——先开启要同步的轨（全局记忆/用户档案/每日日志/待办）', 'No global track is enabled — turn on the tracks to sync (global memory / user profile / daily log / todos)'],
+  'sync.noGlobalTracksSwitches': ['未开启任何全局轨——先打开要同步的轨开关', 'No global track is enabled — flip on the switches of the tracks to sync'],
+  'sync.sharedDisabled': ['共享记忆库已停用（数据与地址保留，可随时重新启用）', 'Shared memory disabled (data and the repo URL are kept; re-enable any time)'],
+  'sync.emptyRepoUrl': ['共享记忆仓库地址不能为空', 'The shared-memory repo URL must not be empty'],
+  'sync.sharedNotInit': ['共享记忆库尚未初始化——先保存仓库地址', 'Shared memory is not initialized — save the repo URL first'],
+  'sync.noGitRemote': ['当前项目没有可共享的 git 远端——请先为主仓库配置 remote（或在下方填共享记忆仓库地址）', 'This project has no shareable git remote — configure a remote on the main repo first (or fill in the shared-memory repo URL below)'],
+  'sync.switchRemoteFailed': ['切换记忆远端失败：remote set-url 未成功（本地记忆未受影响）', 'Switching the memory remote failed: remote set-url did not succeed (local memory unaffected)'],
+  'sync.remoteSwitched': [
+    '记忆远端已切换（{url}，分支 {branch}）。本地记忆完整保留——点「同步」完成首次对账（推送需点「同步并推送」）{note}',
+    'Memory remote switched ({url}, branch {branch}). Local memory fully retained — press "Sync" for the first reconciliation (pushing needs "Sync & Push"){note}',
+  ],
+  'sync.connected': [
+    '已接入远端记忆（{branch}）：{message}。点「同步」拉取合并{tail}',
+    'Connected to the remote memory (branch {branch}): {message}. Press "Sync" to fetch and merge{tail}',
+  ],
+  'sync.setupDone': [
+    '记忆同步初始化完成（{branch}）：{message}。{pushHint}{note}',
+    'Memory-sync initialization complete (branch {branch}): {message}. {pushHint}{note}',
+  ],
+  'sync.needSetupFirst': ['当前项目尚未初始化同步——请先点「开始同步」', 'This project has not initialized sync — press "Start Sync" first'],
+  'sync.offNeedReenable': ['本项目已停用同步（记忆保留本地）——到记忆同步 Tab 重新启用', 'Sync is disabled for this project (memory kept locally) — re-enable it in the Memory Sync tab'],
+  'sync.globalUsage': ['用法：global on|off <memory|user|daily|todo>', 'Usage: global on|off <memory|user|daily|todo>'],
+  'sync.globalStatusToggled': [
+    '全局{track}同步已{state}（{tracks}）',
+    'Global {track} sync {state} ({tracks})',
+  ],
+  'sync.globalNotInitShort': ['全局记忆同步未初始化——全局记忆（用户档案/每日日志/待办）仅共享记忆仓库可用：先填共享记忆仓库地址初始化', 'Global memory sync is not initialized — global tracks (user profile / daily log / todos) require a shared-memory repo: fill in its URL first'],
+  'sync.globalUsageLong': ['用法：global status | global on|off <memory|user|daily|todo> | global sync [--push]', 'Usage: global status | global on|off <memory|user|daily|todo> | global sync [--push]'],
+  'sync.nothingToDisable': ['当前项目尚未初始化同步（无需停用）', 'This project never initialized sync (nothing to disable)'],
+  'sync.disabledLong': ['本项目已停用同步：记忆完整保留在本机，不再对账；重新启用随时可继续（记忆同步 Tab）', 'Sync disabled for this project: memory stays fully on this machine and will no longer reconcile; re-enable any time from the Memory Sync tab'],
+  'sync.moduleDisabled': ['记忆同步模块未启用——在「Memory Evolve 设置 → 配置」打开', 'The memory-sync module is disabled — enable it under "Memory Evolve Settings → Configuration"'],
+  'sync.moduleOnProjectNotInit': ['模块已启用，但当前项目未初始化——点下方「开始同步」', 'The module is enabled, but this project is not initialized — press "Start Sync" below'],
+  'sync.resolveUsageHint': ['用法：conflict resolve <编号> ours | theirs | both [fileset]（编号来自 conflict list）', 'Usage: conflict resolve <number> ours | theirs | both [fileset] (numbers come from conflict list)'],
+  'sync.resolveUsage': ['用法：conflict resolve <编号> ours | theirs | both [fileset]', 'Usage: conflict resolve <number> ours | theirs | both [fileset]'],
+  'sync.conflictUsage': ['用法：conflict list [fileset] | conflict resolve <编号> ours | theirs | both [fileset]', 'Usage: conflict list [fileset] | conflict resolve <number> ours | theirs | both [fileset]'],
+  'sync.noConflicts': ['没有待处理的同步冲突。', 'No pending sync conflicts.'],
+  'sync.noLegacyDir': ['没有发现可迁移的旧记忆目录（当前身份与历史目录一致）。', 'No legacy memory directory found to migrate (current identity matches the history).'],
+  'sync.legacyFound': ['发现旧记忆目录：{legacy}\n→ 点「开始同步」会自动迁移到新目录 {dir}（记入迁移日志）。', 'Legacy memory directory found: {legacy}\n→ "Start Sync" migrates it into the new directory {dir} automatically (recorded in the migration log).'],
+  'sync.unknownSub': ['未知子命令 "{op}"。用法：setup [url] | sync [--push] | off | status | conflict list | migrate', 'Unknown subcommand "{op}". Usage: setup [url] | sync [--push] | off | status | conflict list | migrate'],
+}
+
+/** Memory-sync repo plumbing messages (lib/sync/repo.js). */
+export const SYNC_REPO_DICT = {
+  'syncr.probeFailed': ['无法连接记忆远端（{reason}）：{detail}。请检查网络/凭证后重试', 'Cannot reach the memory remote ({reason}): {detail}. Check network/credentials and retry'],
+  'syncr.adoptShared': ['远端已有本项目的专属分支 {branch}，直接接入', 'The remote already has this project\'s dedicated branch {branch}; adopting it directly'],
+  'syncr.fetchLegacyFail': ['无法读取远端分支 {branch} 的内容（{detail}）——已停止初始化，请检查远端后重试', 'Cannot read the content of remote branch {branch} ({detail}) — initialization stopped; check the remote and retry'],
+  'syncr.gitInitFail': ['git 初始化失败：{detail}', 'git init failed: {detail}'],
+  'syncr.legacyContinue': ['远端分支 {branch} 是本项目的记忆（老配置）——继续使用，零迁移', 'Remote branch {branch} holds this project\'s memory (legacy layout) — continuing with it, zero migration'],
+  'syncr.freshBranch': ['{others}本项目使用专属分支 {branch}', '{others}This project uses dedicated branch {branch}'],
+  'syncr.othersPresent': ['远端已有其他项目的分支——', 'The remote already hosts other projects\' branches — '],
+  'syncr.freshRemote': ['全新记忆远端——', 'Fresh memory remote — '],
+  'syncr.migrateFail': ['记忆目录迁移失败：{detail}。请人工检查 {memoryDir}/projects/ 下是否有两个同项目目录后重试。', 'Memory directory migration failed: {detail}. Manually check for two same-project directories under {memoryDir}/projects/ and retry.'],
+  'syncr.initFail': ['git init 失败（{detail}）——请检查 git 是否可用', 'git init failed ({detail}) — check that git is available'],
+  'syncr.mainBranchFail': ['无法设置默认分支 main（{detail}）', 'Cannot set the default branch to main ({detail})'],
+  'syncr.provenanceCorrupt': ['PROVENANCE 已存在但无法解析（JSON 损坏）——请人工检查后重试', 'PROVENANCE exists but cannot be parsed (corrupt JSON) — inspect it manually and retry'],
+  'syncr.identityMismatch': [
+    '目录身份不匹配：现有 PROVENANCE 属于项目 {existing}（{displayName}），当前解析为 {current}。目录可能被误用或接错，已停止初始化',
+    'Directory identity mismatch: the existing PROVENANCE belongs to project {existing} ({displayName}), but this resolves to {current}. The directory may be misused or miswired; initialization stopped',
+  ],
+  'syncr.commitFail': ['首次提交失败：{detail}', 'The initial commit failed: {detail}'],
+  'syncr.remoteAddFail': ['remote 挂载失败：{detail}', 'Attaching the remote failed: {detail}'],
+  'syncr.remoteUnreachable': [
+    '无法连接远端记忆仓库（{reason}）：{detail}。已跳过初始化，本地记忆不受影响；请检查网络/凭证后重试。',
+    'Cannot reach the remote memory repo ({reason}): {detail}. Initialization skipped; local memory unaffected. Check network/credentials and retry.',
+  ],
+  'syncr.bootstrapNeeded': ['远端尚无 {branch} 分支，将按新设备初始化', 'Remote branch {branch} does not exist yet; initializing as a new device'],
+  'syncr.idempotentAdopt': ['本项目已接入（重复 setup 幂等，无需重新初始化）', 'This project is already connected (setup is idempotent; no re-initialization needed)'],
+  'syncr.dirNotEmpty': [
+    '目标目录 {dir} 已有记忆内容（{files}）——为避免覆盖本地记忆，请先清空目录或人工处理后再接入',
+    'Target directory {dir} already holds memory content ({files}) — to avoid overwriting local memory, empty the directory or handle it manually before connecting',
+  ],
+  'syncr.gitInitFailShort': ['git init 失败：{detail}', 'git init failed: {detail}'],
+  'syncr.remoteAddFailShort': ['remote 挂载失败：{detail}', 'Attaching the remote failed: {detail}'],
+  'syncr.fetchFail': ['拉取远端记忆失败：{detail}', 'Fetching the remote memory failed: {detail}'],
+  'syncr.noProvenance': ['远端分支 {branch} 没有 PROVENANCE（身份缺失）——无法确认归属本项目，已拒绝接入（防串项目）。请人工检查远端分支后重试', 'Remote branch {branch} has no PROVENANCE (identity missing) — cannot confirm it belongs to this project; connection refused (cross-project guard). Inspect the remote branch manually and retry'],
+  'syncr.provenanceBroken': ['远端分支 {branch} 的 PROVENANCE 损坏（无法解析 JSON）——已拒绝接入（防串项目）。请人工检查远端分支后重试', 'Remote branch {branch} has a corrupt PROVENANCE (unparseable JSON) — connection refused (cross-project guard). Inspect the remote branch manually and retry'],
+  'syncr.identityMismatchRemote': ['远端记忆属于项目 {projectId}（{displayName}），与当前项目 {expected} 不匹配——疑似接错了分支/仓库，已拒绝接入', 'The remote memory belongs to project {projectId} ({displayName}), which does not match the current project {expected} — likely the wrong branch/repo; connection refused'],
+  'syncr.checkoutFail': ['检出远端记忆失败：{detail}', 'Checking out the remote memory failed: {detail}'],
+  'syncr.adopted': ['已接入远端记忆（{branch}）', 'Connected to the remote memory (branch {branch})'],
+  'syncr.globalInitFail': ['全局记忆仓库 git init 失败：{detail}', 'Global memory repo git init failed: {detail}'],
+  'syncr.globalMainFail': ['无法设置默认分支 main：{detail}', 'Cannot set the default branch to main: {detail}'],
+  'syncr.globalStageFail': ['全局记忆文件 stage 失败（{path}）：{detail}', 'Staging the global memory file failed ({path}): {detail}'],
+  'syncr.globalCommitFail': ['全局记忆仓库首次提交失败：{detail}', 'Global memory repo initial commit failed: {detail}'],
+  'syncr.globalRemoteAddFail': ['全局记忆仓库 remote 挂载失败：{detail}', 'Global memory repo remote attach failed: {detail}'],
+  'syncr.globalRemoteSetFail': ['全局记忆仓库 remote 切换失败：{detail}', 'Global memory repo remote switch failed: {detail}'],
+}
+
+/** Memory-sync worker messages (lib/sync/worker.js). */
+export const SYNC_WORKER_DICT = {
+  'syncw.notInit': ['记忆仓库尚未初始化——请先在记忆同步 Tab 点「开始同步」初始化', 'The memory repo is not initialized — press "Start Sync" in the Memory Sync tab first'],
+  'syncw.conflictsPending': ['还有 {count} 条冲突未解决（{file}）——请先在冲突区解决后再同步', '{count} conflict(s) remain unresolved ({file}) — resolve them in the conflicts area before syncing'],
+  'syncw.disabledResume': ['本项目已停用同步（记忆完整保留本地）——重新启用后继续', 'Sync is disabled for this project (memory fully kept locally) — re-enable to continue'],
+  'syncw.noTracksSelected': ['项目记忆轨已退出同步（未选择任何同步内容）', 'Project memory tracks left the sync (no sync content selected)'],
+  'syncw.pullFail': ['拉取远端记忆失败（{err}）。本地记忆未受影响，请检查网络/凭证后重试', 'Fetching the remote memory failed ({err}). Local memory unaffected; check network/credentials and retry'],
+  'syncw.branchGone': ['远端分支 {branch} 已不存在（本地曾有陈旧跟踪，已清理）。远端记忆可能被删除或迁移——请检查远端后重新初始化', 'Remote branch {branch} no longer exists (a stale local tracking ref was cleaned up). The remote memory may have been deleted or moved — check the remote and re-initialize'],
+  'syncw.branchMissing': ['远端分支 {branch} 不存在——请先点「开始同步」初始化', 'Remote branch {branch} does not exist — press "Start Sync" to initialize first'],
+  'syncw.remoteInvalid': ['远端记忆数据格式异常（{path}：{reason}）——已停止同步，本地记忆未受影响。请人工检查远端分支后重试', 'Remote memory data is malformed ({path}: {reason}) — sync stopped, local memory unaffected. Inspect the remote branch manually and retry'],
+  'syncw.historyDiverged': ['历史无法对齐（可能被 force 推送或接错了分支）——已停止合并，本地记忆未受影响。请人工检查远端分支后重试', 'Histories cannot be aligned (force-pushed or wrong branch?) — merge stopped, local memory unaffected. Inspect the remote branch manually and retry'],
+  'syncw.baseInvalid': ['历史数据格式异常（{path}：{reason}）——已停止合并，本地记忆未受影响。请人工检查后重试', 'Historical data is malformed ({path}: {reason}) — merge stopped, local memory unaffected. Inspect it manually and retry'],
+  'syncw.commitAfterMergeFail': ['合并完成但提交失败：{detail}。工作树已是合并结果，请重试', 'Merge completed but the commit failed: {detail}. The working tree already holds the merged result; retry'],
+  'syncw.conflictsBeforePush': ['还有 {count} 条冲突未解决（{file}）——请先解决冲突再推送，否则远端会缺少冲突条目', '{count} conflict(s) remain unresolved ({file}) — resolve before pushing or the remote will miss the conflicted entries'],
+  'syncw.pushRejected': ['推送被拒绝：远端有新提交（non-fast-forward）。请先再点一次「同步」拉取合并后再推，绝不强制推送', 'Push rejected: the remote has new commits (non-fast-forward). Press "Sync" again to fetch and merge first; never force-push'],
+  'syncw.pushFail': ['推送失败（{detail}）。合并结果已安全保存在本地，可稍后重试', 'Push failed ({detail}). The merged result is safely stored locally; retry later'],
+  'syncw.unknownError': ['未知错误', 'unknown error'],
+  'syncw.statusNotInit': ['未初始化', 'not initialized'],
+  'syncw.statusInit': ['初始化：{state}', 'Initialization: {state}'],
+  'syncw.connectedState': ['已接入', 'connected'],
+  'syncw.notConnected': ['未接入远端', 'not connected to a remote'],
+  'syncw.identityMismatchMerge': [
+    '远端记忆身份缺失或不匹配（本地项目 {local}）。疑似远端分支被篡改或接错——已拒绝合并。请检查后重试',
+    'Remote memory identity missing or mismatched (local project {local}). The remote branch may be tampered with or miswired — merge refused. Check and retry',
+  ],
+  'syncw.noConflicts': ['没有待处理的冲突', 'No pending conflicts'],
+  'syncw.badConflictIndex': ['冲突编号 {index} 不存在（当前 1..{max}）', 'Conflict number {index} does not exist (valid range 1..{max})'],
+  'syncw.resolveUsage': ['用法：conflict resolve <编号> ours | theirs | both', 'Usage: conflict resolve <number> ours | theirs | both'],
+  'syncw.choiceUnavailable': ['冲突 {index} 没有可用的 {choice} 版本（该侧为空/删除）', 'Conflict {index} has no {choice} side available (that side is empty/deleted)'],
+  'syncw.fileNotWhitelisted': ['冲突 {index} 的目标文件不在同步白名单内（{file}）——已拒绝写入', "Conflict {index}'s target file is not in the sync whitelist ({file}) — write refused"],
+  'syncw.treeStepFail': ['解决冲突时 {error}（目标条目已写回，可重试）', '{error} while resolving the conflict (the target entry is written back; safe to retry)'],
+  'syncw.commitTreeFail': ['解决冲突时 commit-tree 失败：{detail}（目标条目已写回且写回幂等，可直接重试）', 'commit-tree failed while resolving: {detail} (the target entry is written back idempotently; retry directly)'],
+  'syncw.updateRefFail': ['解决冲突时 update-ref 失败：{detail}。提交已生成但 ref 未更新——侧车仍在，写回幂等，请重试', 'update-ref failed while resolving: {detail}. The commit exists but the ref was not updated — the sidecar remains, writes are idempotent; retry'],
+  'syncw.resolved': ['已解决冲突 #{index}（{choice}）并提交', 'Conflict #{index} resolved ({choice}) and committed'],
 }

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -1262,3 +1262,13 @@ export const SYNC_WORKER_DICT = {
   'syncw.updateRefFail': ['解决冲突时 update-ref 失败：{detail}。提交已生成但 ref 未更新——侧车仍在，写回幂等，请重试', 'update-ref failed while resolving: {detail}. The commit exists but the ref was not updated — the sidecar remains, writes are idempotent; retry'],
   'syncw.resolved': ['已解决冲突 #{index}（{choice}）并提交', 'Conflict #{index} resolved ({choice}) and committed'],
 }
+
+/** COI task-completion notification mail body (lib/coi/index.js). */
+export const NOTIFY_DICT = {
+  'coin.head': ['[COI] 任务 {id}（{name}）{status}', '[COI] Task {id} ({name}) {status}'],
+  'coin.subject': ['📮 主题：任务完成：{id}（{name}）', '📮 Subject: Task finished: {id} ({name})'],
+  'coin.intro': ['📝 简介：{intro}', '📝 Intro: {intro}'],
+  'coin.sender': ['👤 发送人：DSH AI 助手（dsh-memory-evolve）', '👤 Sender: DSH AI assistant (dsh-memory-evolve)'],
+  'coin.time': ['🕐 时间：{time}', '🕐 Time: {time}'],
+  'coin.bodyHead': ['📄 内容', '📄 Content'],
+}

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -697,3 +697,231 @@ export const MISC_DICT = {
     'Unknown operation "{op}" (supported: list / approve / archive / reject / approve-all / reject-all)',
   ],
 }
+
+/** Todo execute-time messages (lib/todo.js). */
+export const TODO_MSG_DICT = {
+  'todomsg.emptyContent': ['待办内容不能为空', 'Todo content must not be empty'],
+  'todomsg.added': ['已添加待办（{target}：{count} 条）', 'Todo added ({target}: {count} item(s))'],
+  'todomsg.notFoundTrack': [
+    '没有找到 id 为 "{id}" 的待办（{target} 轨）',
+    'No todo with id "{id}" ({target} track)',
+  ],
+  'todomsg.notFound': ['没有找到 id 为 "{id}" 的待办', 'No todo with id "{id}"'],
+  'todomsg.gone': [
+    '该待办已被删除（可能在其他窗口操作）——请刷新后重试',
+    'This todo was already deleted (edited in another window?) — refresh and retry',
+  ],
+  'todomsg.updated': ['已更新待办（{target}）', 'Todo updated ({target})'],
+  'todomsg.deleted': ['已删除待办（{target}）', 'Todo deleted ({target})'],
+  'todomsg.invalidTarget': [
+    '无效 target "{target}"（应为 {valid}）',
+    'Invalid target "{target}" (expected one of {valid})',
+  ],
+  'todomsg.unknownAction': ['未知 action "{action}"', 'Unknown action "{action}"'],
+}
+
+/** Skill execute-time messages (lib/skills.js). */
+export const SKILL_MSG_DICT = {
+  'skillmsg.invalidNameShort': ['无效技能名 "{name}"', 'Invalid skill name "{name}"'],
+  'skillmsg.pendingMissing': ['待确认技能 "{name}" 不存在', 'Pending skill "{name}" does not exist'],
+  'skillmsg.alreadyInLib': [
+    '技能 "{name}" 已存在于技能库，请先处理再采纳',
+    'Skill "{name}" already exists in the library; resolve it before adopting',
+  ],
+  'skillmsg.listHead': ['技能库（{count} 个）：', 'Skill library ({count}):'],
+  'skillmsg.invalidNameCase': [
+    '无效技能名 "{name}"（必须 kebab-case 小写）',
+    'Invalid skill name "{name}" (must be lowercase kebab-case)',
+  ],
+  'skillmsg.missing': ['技能 "{name}" 不存在', 'Skill "{name}" does not exist'],
+  'skillmsg.read': ['已读取技能 "{name}"（{bytes} 字节）', 'Read skill "{name}" ({bytes} bytes)'],
+  'skillmsg.existsUsePatch': [
+    '技能 "{name}" 已存在，请改用 patch 更新',
+    'Skill "{name}" exists; use patch to update it',
+  ],
+  'skillmsg.pendingDuplicate': [
+    '待确认队列已有技能 "{name}"，请勿重复创建（可在设置面板处理）',
+    'The pending queue already holds "{name}"; do not create it twice (handle it in the settings panel)',
+  ],
+  'skillmsg.createdPending': [
+    '技能 "{name}" 已创建到待确认队列（等待用户在设置面板确认采纳，采纳后才会进入技能库）',
+    'Skill "{name}" entered the pending queue (it joins the library only after the user adopts it in the settings panel)',
+  ],
+  'skillmsg.created': ['技能 "{name}" 已创建（{bytes} 字节）', 'Skill "{name}" created ({bytes} bytes)'],
+  'skillmsg.missingUseCreate': [
+    '技能 "{name}" 不存在，请改用 create',
+    'Skill "{name}" does not exist; use create first',
+  ],
+  'skillmsg.readFirst': [
+    '更新技能 "{name}" 前必须先读取它：请先调用 {tool} action=read name={name}',
+    'Read skill "{name}" before updating it: call {tool} action=read name={name} first',
+  ],
+  'skillmsg.updated': ['技能 "{name}" 已更新（{bytes} 字节）', 'Skill "{name}" updated ({bytes} bytes)'],
+  'skillmsg.unknownAction': [
+    '未知操作 "{action}"（支持 create / patch / read / list）',
+    'Unknown action "{action}" (supported: create / patch / read / list)',
+  ],
+}
+
+/** Prompt tool messages (lib/prompts.js). */
+export const PROMPT_DICT = {
+  'promptmsg.injectedOnce': [
+    '【立即注入】提示词「{name}」已生效（仅此一次）——请查看快照「用户规则」并立即遵循。',
+    '[Injected now] Prompt "{name}" took effect (this turn only) — see the "User rules" snapshot section and follow it immediately.',
+  ],
+  'promptmsg.getNeedsId': ['get 需要 id（来自 list 返回）', 'get needs an id (as returned by list)'],
+  'promptmsg.missingGet': ['提示词不存在：{id}（可先 list 查看可用提示词）', 'Prompt not found: {id} (run list to see available prompts)'],
+  'promptmsg.detail': [
+    '「{name}」详情（{status}，已注入 {count} 次）',
+    '"{name}" details ({status}, injected {count} time(s))',
+  ],
+  'promptmsg.enabled': ['启用中', 'enabled'],
+  'promptmsg.disabled': ['已禁用', 'disabled'],
+  'promptmsg.created': [
+    '已创建提示词「{name}」（分类：{category}，id={id}）——可 inject 注入当前会话，或 update <id> 继续修改',
+    'Prompt "{name}" created (category: {category}, id={id}) — inject it into the current session, or update <id> to keep editing',
+  ],
+  'promptmsg.updateNeedsId': [
+    'update 需要 id（来自 list 返回或 create 结果）',
+    'update needs an id (from list output or the create result)',
+  ],
+  'promptmsg.updateNoFields': [
+    'update 至少要改一个字段（name/content/description/category/tags/enabled）',
+    'update must change at least one field (name/content/description/category/tags/enabled)',
+  ],
+  'promptmsg.updated': [
+    '已更新提示词「{name}」（分类：{category}，enabled={enabled}）',
+    'Prompt "{name}" updated (category: {category}, enabled={enabled})',
+  ],
+  'promptmsg.injectNeedsId': ['inject 需要 id（来自 list 返回）', 'inject needs an id (as returned by list)'],
+  'promptmsg.missingInject': ['提示词不存在：{id}（可先 list 查看可用提示词）', 'Prompt not found: {id} (run list to see available prompts)'],
+  'promptmsg.cannotInjectDisabled': [
+    '「{name}」已禁用，不能注入（可在 GUI 提示词库中重新启用）',
+    '"{name}" is disabled and cannot be injected (re-enable it in the GUI prompt library)',
+  ],
+  'promptmsg.alreadyInjecting': [
+    '「{name}」已在注入中（可先在 GUI「注入中」移除再重新注入）',
+    '"{name}" is already injecting (remove it from the GUI "Injecting" list, then inject again)',
+  ],
+  'promptmsg.injectNow': [
+    '已立即注入「{name}」：当前回合生效，仅此一次（不受次数/间隔影响）{tail}',
+    'Injected "{name}" now: takes effect this turn, once only (ignores count/interval){tail}',
+  ],
+  'promptmsg.steerMissed': ['（插话未送达——将在下一轮生效）', '(the interjection was not delivered — it applies next turn instead)'],
+  'promptmsg.roundsInvalid': ['rounds 必须是 ≥1 的整数，或 0 表示无限', 'rounds must be an integer ≥1, or 0 for unlimited'],
+  'promptmsg.everyInvalid': ['every 必须是 ≥0 的整数（0 = 只注入一次）', 'every must be an integer ≥0 (0 = inject once)'],
+  'promptmsg.injectScheduled': [
+    '已注入「{name}」：{times}{cadence}，模型下一轮生效{ending}',
+    'Injected "{name}": {times}{cadence}; the model picks it up next turn{ending}',
+  ],
+  'promptmsg.unknownAction': [
+    '未知 action：{action}（支持 list / get / inject）',
+    'Unknown action {action} (supported: list / get / inject)',
+  ],
+}
+
+/** de_session (session-orch) messages (lib/session-orch.js). */
+export const SESSION_DICT = {
+  'ses.msg.renameNeedsSid': ['rename 必填 sessionId（要改名的会话）', 'rename needs sessionId (the session to rename)'],
+  'ses.msg.renameNeedsOne': [
+    'rename 至少提供 title（会话名称）或 alias（会话别名）之一',
+    'rename needs at least one of title (session name) or alias (session alias)',
+  ],
+  'ses.msg.notLoadedRename': [
+    '会话 {sid} 不在当前进程，无法改名称（可先 wake 恢复再改，或用 list 确认 ID）',
+    'Session {sid} is not loaded in this process; cannot rename it (wake it first, or confirm the ID with list)',
+  ],
+  'ses.msg.renameFailed': ['改会话名称失败: {detail}', 'Renaming failed: {detail}'],
+  'ses.msg.aliasStoreMissing': ['别名存储不可用（aliases.json）', 'Alias storage unavailable (aliases.json)'],
+  'ses.msg.noRequester': ['无法获取当前会话信息（调用上下文缺少 agent）', 'Cannot resolve the current session (call context lacks an agent)'],
+  'ses.msg.noSelfId': ['无法获取当前会话 ID', 'Cannot resolve the current session ID'],
+  'ses.msg.spawnNeedsPrompt': [
+    'spawn 必填 prompt（新会话的完整提示词，可长文本自由组合：角色/任务/要求一次写清）',
+    'spawn needs prompt (the new session\'s full brief — role/task/requirements may be one long free-form text)',
+  ],
+  'ses.msg.badPreset': [
+    'agentPreset 格式不合法："{preset}"（须匹配 [a-z0-9][a-z0-9-]*，如 code/cordis/minimal/standard）',
+    'Invalid agentPreset "{preset}" (must match [a-z0-9][a-z0-9-]*, e.g. code/cordis/minimal/standard)',
+  ],
+  'ses.msg.spawnFailed': ['创建会话失败: {detail}', 'Session creation failed: {detail}'],
+  'ses.msg.dispatchFailed': [
+    '会话 {sid} 已创建但派发初始任务失败: {detail}',
+    'Session {sid} was created but dispatching its initial task failed: {detail}',
+  ],
+  'ses.msg.spawned': [
+    '已创建会话 {sid} 并开始执行任务{notes}',
+    'Session {sid} created and task started{notes}',
+  ],
+  'ses.msg.wakeNeedsSid': ['wake 必填 sessionId（要唤醒的会话 ID）', 'wake needs sessionId (the session to wake)'],
+  'ses.msg.wakeNeedsPrompt': [
+    'wake 必填 prompt（要对方做的事，如"现在开始执行：…"）',
+    'wake needs prompt (what the other session should do, e.g. "start now: …")',
+  ],
+  'ses.msg.wakeRestoreFailed': [
+    '会话 {sid} 不在当前进程且自动恢复失败（可能不存在/是跨实例会话/持久化不可用）: {detail}',
+    'Session {sid} is not in this process and auto-restore failed (missing? cross-instance? persistence unavailable?): {detail}',
+  ],
+  'ses.msg.wakeFailed': ['唤醒会话 {sid} 失败: {detail}', 'Waking session {sid} failed: {detail}'],
+  'ses.msg.wakeQueued': [
+    '指令已送达会话 {sid}（已入队）。⚠️ 送达≠成功：对方实际能否跑起来需**稍后确认**——离线恢复或模型配置缺失时回合可能失败。等几秒后 de_session status 查它是否 running；忙完前不要重复派活',
+    'Delivered to session {sid} (queued). ⚠️ Delivered ≠ succeeded: confirm later that it actually runs — a restored offline session or a missing model config can fail the turn. Check de_session status after a few seconds; do not re-dispatch while it is busy',
+  ],
+  'ses.msg.statusNeedsSid': ['status 必填 sessionId', 'status needs a sessionId'],
+  'ses.msg.statusOffline': [
+    '会话不在当前进程（离线或不存在；同实例会话重启后会自动恢复）',
+    'Session is not loaded in this process (offline or nonexistent; same-instance sessions restore automatically after a restart)',
+  ],
+  'ses.msg.statusLine': [
+    '会话 {sid} 状态：{status}（{detail}）',
+    'Session {sid} status: {status} ({detail})',
+  ],
+  'ses.msg.statusRunning': ['正在生成', 'generating'],
+  'ses.msg.statusIdle': ['空闲，等指令', 'idle, awaiting instructions'],
+  'ses.msg.findNeedsQuery': [
+    'find 必填 query（要查找的名称/别名/ID 关键字）',
+    'find needs query (a name/alias/ID keyword to search for)',
+  ],
+  'ses.msg.broadcastDisabled': [
+    '广播模块未启用（可在运行时配置打开「会话广播」）',
+    'The broadcast module is disabled (turn on "session broadcast" in the runtime configuration)',
+  ],
+  'ses.msg.orchNotReady': ['会话编排未就绪（DSH agents 服务不可用）', 'Session orchestration not ready (the DSH agents service is unavailable)'],
+  'ses.msg.unknownAction': ['未知 action "{action}"', 'Unknown action "{action}"'],
+  'ses.msg.actionFailed': ['de_session {action} 失败: {detail}', 'de_session {action} failed: {detail}'],
+}
+
+/** Small-module messages: search-docs, advisor, aliases, api, canvas, update, notify. */
+export const MISC2_DICT = {
+  'sd.badExts': ['exts 参数格式不正确（应为扩展名数组或逗号分隔字符串）', 'Invalid exts parameter (expected an array or comma-separated string of extensions)'],
+  'sd.contentNeedsQuery': ['内容检索需要关键词：请提供 contentQuery，或同时提供 query（content=true 时复用 query）', 'Content search needs keywords: provide contentQuery, or supply query too (content=true reuses query)'],
+  'sd.enabled': ['已启用本地文档搜索工具（{tool}）。provider 链：{chain}', 'Local docs search enabled ({tool}). Provider chain: {chain}'],
+  'sd.disabled': ['已禁用本地文档搜索工具：工具已从模型可见列表中移除', 'Local docs search disabled: the tool was removed from the model-visible list'],
+  'sd.status': ['本地文档搜索工具：{state}\n工具名：{tool}\nprovider 链：{chain}\n默认扩展名：{exts}\n用法：/memory_evolve_search_docs on|off', 'Local docs search: {state}\nTool name: {tool}\nProvider chain: {chain}\nDefault extensions: {exts}\nUsage: /memory_evolve_search_docs on|off'],
+  'sd.on': ['已启用', 'enabled'],
+  'sd.off': ['已禁用（默认）', 'disabled (default)'],
+  'adv.noSession': ['无法识别当前会话', 'Cannot identify the current session'],
+  'adv.globalOff': ['Advisor 全局开关未开启：请先在 设置 → 配置 打开「会话评审（Advisor）」，再为会话单独{verb}', 'The Advisor global switch is off: enable "Session review (Advisor)" under Settings → Configuration first, then toggle this session {verb}'],
+  'adv.cannotReset': ['无法重置：本会话 Advisor 未启用或运行时不可用', 'Cannot reset: Advisor is not enabled for this session or its runtime is unavailable'],
+  'adv.resetDone': ['已新建评审会话（#{epoch}）——评审员上下文已清空，可在第一条指令中告知背景信息。', 'Review session restarted (#{epoch}) — the reviewer context is clear; you may provide background in your first instruction.'],
+  'adv.tellEmpty': ['指令不能为空：/advisor tell <指令内容>', 'Instruction must not be empty: /advisor tell <instruction>'],
+  'adv.tellQueued': ['指令已入队：{text}', 'Instruction queued: {text}'],
+  'adv.rateLimited': ['评审调用被限流：{detail}', 'Review call rate-limited: {detail}'],
+  'adv.droppedAfterRetries': ['评审调用多次失败，本轮丢弃', 'Review call failed repeatedly; dropped for this turn'],
+  'adv.aborted': ['评审被中止（会话销毁/停用）', 'Review aborted (session destroyed or disabled)'],
+  'adv.deliveryFailed': ['投递失败（缺 agent 或 steer 抛错）', 'Delivery failed (missing agent or steer threw)'],
+  'adv.emptyAnswer': ['advisor 问答返回空回答', 'The advisor Q&A returned an empty answer'],
+  'adv.recordTooLarge': ['评审记录超限（{bytes} 字节），已跳过落盘', 'Review record exceeds the size limit ({bytes} bytes); not persisted'],
+  'adv.recordWriteFailed': ['评审记录落盘失败：{detail}', 'Persisting the review record failed: {detail}'],
+  'adv.lineCorrupt': ['records.jsonl 第 {line} 行损坏，已跳过：{detail}', 'records.jsonl line {line} is corrupt and was skipped: {detail}'],
+  'alias.needsSid': ['会话 id 不能为空', 'Session id must not be empty'],
+  'alias.cleared': ['已清除会话别名', 'Session alias cleared'],
+  'alias.tooLong': ['别名最多 {max} 个字（当前 {len} 字）', 'Alias is limited to {max} chars (got {len})'],
+  'alias.set': ['会话别名已设为「{alias}」', 'Session alias set to "{alias}"'],
+  'api.syncNotAssembled': ['同步模块未装配', 'Sync module is not assembled'],
+  'api.archivedOk': ['已归档（{target}：归档文件现有 {count} 条；{detail}）', 'Archived ({target}: the archive file now holds {count} entries; {detail})'],
+  'canvas.failed': ['画板操作失败：{detail}', 'Canvas operation failed: {detail}'],
+  'canvas.unknownError': ['未知错误', 'unknown error'],
+  'upd.notGitRepo': ['插件目录不是 git 仓库或 git 不可用（请用 git clone 安装）', 'The plugin directory is not a git repo or git is unavailable (install via git clone)'],
+  'upd.remoteCheckFailed': ['远端检测失败（{kind}）', 'Remote check failed ({kind})'],
+  'notify.missing': ['通知 {id} 不存在', 'Notification {id} does not exist'],
+}

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -443,6 +443,7 @@ export const TODO_DICT = {
 
 /** Skill-management tool strings (lib/skills.js). */
 export const SKILL_DICT = {
+  'skill.listHeader': ['已有技能（{count} 个）：', 'Existing skills ({count}):'],
   'skill.desc': [
     '管理技能库（默认目录 ~/.agents/skills，DSH 技能库）：create 创建新技能（body 为完整 SKILL.md，含 --- frontmatter：name 与 description 单行必填）；patch 更新已有技能（必须先用 read 读取过，body 为完整修订版）；read 读取技能全文；list 列出已有技能。技能命名必须 kebab-case 类级名称（如 systematic-debugging），禁止一次性任务名。',
     'Manage the skill library (default directory ~/.agents/skills, the DSH skill store): create adds a new skill (body is a full SKILL.md including --- frontmatter with single-line name and description); patch updates an existing skill (read it first; body is the full revised version); read returns a skill\'s full text; list enumerates skills. Skill names must be kebab-case class-like names (e.g. systematic-debugging); one-off task names are rejected.',
@@ -983,6 +984,10 @@ export const BROADCAST_DICT = {
 
 /** COI scheduler + command messages (lib/coi/scheduler.js, lib/coi/commands.js). */
 export const COI_DICT = {
+  'coi.template.name.review-code': ['Review 代码', 'Code review'],
+  'coi.template.name.fix-tests': ['修复测试', 'Fix tests'],
+  'coi.template.name.summarize-logs': ['总结日志', 'Summarize logs'],
+  'coi.template.name.architecture-analysis': ['架构分析', 'Architecture analysis'],
   'coi.disposed': ['调度器已销毁', 'The scheduler has been disposed'],
   'coi.adapterUnknownHint': ['未知适配器 "{id}"（可用 de_coi_adapters 查看可用适配器与适用场景）', 'Unknown adapter "{id}" (run de_coi_adapters to list adapters and their use cases)'],
   'coi.adapterDisabled': ['适配器 {id}（{name}）已被禁用。可用适配器：{available}（可用 de_coi_adapters 查看适用场景）', 'Adapter {id} ({name}) is disabled. Available adapters: {available} (see de_coi_adapters for use cases)'],

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -1,0 +1,699 @@
+/**
+ * dsh-memory-evolve — host-side i18n runtime (English support, 2026-08-25).
+ *
+ * One source of truth for which language the HOST side (model-facing tool
+ * descriptions, injected snapshot duties, feedback lines, tool result
+ * messages) speaks:
+ *
+ *   resolveLocale():
+ *     1. DSH Settings → General → Language preference (namespace 'locale',
+ *        field 'preference') when the user picked one explicitly ('zh'|'en');
+ *     2. otherwise default 'en'.
+ *
+ * The DSH locale plugin registers the namespace read-only from our side: we
+ * never call settings.update/replace — we only .get() the resolved section
+ * and listen to the 'settings/updated' commit event. When the user flips
+ * Language mid-session, `setLocale` re-resolves and every getter-based tool
+ * description + next-built snapshot/message follows immediately (no restart,
+ * no re-registration — the tools registry reads `definition.description` at
+ * projection time, so plain JS getters are enough).
+ *
+ * Dictionary shape: per-domain flat key → { zh, en } pairs, translated via
+ * t(domain, key, params) with {name} placeholder substitution. Keeping both
+ * languages in one table makes key-parity testable in one pass.
+ *
+ * @module dsh-memory-evolve/i18n
+ */
+
+/** Active host locale. Module-level singleton: one process speaks one language.
+ *  Default 'en': the plugin speaks English unless the DSH Language preference
+ *  is explicitly 'zh'. apply() re-resolves from DSH settings at boot and on
+ *  every locale change event, so live processes always follow the setting. */
+let active = 'en'
+
+/** Valid locale ids (mirrors DSH's LOCALE_IDS). */
+export const LOCALES = ['zh', 'en']
+
+/**
+ * Resolve the effective locale from a Cordis context. Reads the DSH locale
+ * settings section when the settings service exists. Default is 'en': only
+ * an explicit 'zh' preference switches the plugin back to Chinese; unset,
+ * 'auto', or any unexpected value stays English. Never throws.
+ * @param {object|undefined} ctx - plugin context with an optional settings service.
+ * @returns {'zh'|'en'} the resolved locale id.
+ */
+export function resolveLocale(ctx) {
+  try {
+    const settings = ctx?.get?.('settings')
+    if (!settings || typeof settings.get !== 'function') return 'en'
+    const section = settings.get('locale')
+    const pref = section && typeof section === 'object' ? section.preference : undefined
+    return pref === 'zh' ? 'zh' : 'en'
+  } catch {
+    return 'en'
+  }
+}
+
+/**
+ * Set the active locale (validated). The apply() wiring calls this at boot
+ * and on every 'settings/updated' event for the 'locale' namespace.
+ * @param {'zh'|'en'} locale - the new active locale.
+ */
+export function setLocale(locale) {
+  if (LOCALES.includes(locale)) active = locale
+}
+
+/** Read the active locale (mainly for tests). */
+export function getLocale() {
+  return active
+}
+
+/**
+ * Translate one key in the active locale with {name} placeholder params.
+ * Unknown keys fall back to the key itself so missing translations surface
+ * visibly instead of crashing a tool call.
+ * @param {Record<string, [string, string]>} dict - flat map key → [zh, en].
+ * @param {string} key - dictionary key.
+ * @param {object} [params] - placeholder values ({name} style).
+ * @param {'zh'|'en'} [locale] - override the active locale (tests).
+ * @returns {string} the translated string.
+ */
+export function translate(dict, key, params, locale = undefined) {
+  const pair = dict[key]
+  const lang = locale ?? active
+  let text = pair ? (lang === 'zh' ? pair[0] : pair[1]) : key
+  if (params && typeof params === 'object') {
+    text = text.replace(/\{(\w+)\}/g, (m, name) => {
+      const v = params[name]
+      return v === undefined || v === null ? m : String(v)
+    })
+  }
+  return text
+}
+
+/* ------------------------------------------------------------------ */
+/* dictionaries                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Core memory-tool strings: descriptions, parameters, result messages.
+ * Format: KEY: [zh, en]. Keep both cells non-empty (key-parity test).
+ */
+export const MEMORY_DICT = {
+  // ── tool description ──
+  'memory.desc': [
+    '读写长期记忆（跨会话持久，随上下文快照对模型可见）。target=memory 存全局环境/项目事实，target=user 存用户事实，target=project 存当前工作目录的项目日志（仅当前项目会话可见），target=key 存当前项目的关键长期记忆（自动注入上下文，仅当前项目会话可见；支持 branches 限定 git 分支范围，缺省=全部；**写入需用户确认**：add 会进入待确认队列，确认后生效；add 可选 summary 参数提供一句话摘要用于渐进式披露），target=daily 追加今日日志（按需读取，不注入）。add 追加条目；replace 用唯一子串片段替换整个条目；remove 用唯一子串片段删除条目；**archive 把条目归档（仅 memory/user/key 三轨）**：按唯一子串片段从主轨移除整条、原文追加进对应归档文件（MEMORY-archive.md / USER-archive.md / 项目 KEY-archive.md，可逆——记忆 Tab 归档页可移回主记忆），适合"已不再需要注入、但丢之可惜"的低频旧事；list 查询条目——默认查主轨（未归档，全部返回，按时间正序），支持 filter（关键词过滤）、since/until（日期范围 YYYY-MM-DD，daily 可跨文件查历史日志）、limit（最多条数，配合 recent 取最近 N 条）、recent（最新在前）、branch（key 轨：只返回该分支可见的条目）、**archived=true（查对应归档文件 MEMORY-archive.md / USER-archive.md / 项目 KEY-archive.md——仅 memory/user/key 三轨，key 需要会话工作目录；归档不注入，可移回主记忆）**；查不到匹配或日期无法解析时，去掉过滤条件重查。**expand 按需加载全文（渐进式披露）**：当 key 轨为摘要模式时，系统提示词只注入摘要，需要详情时用 expand+id 加载完整条目。**每轮收尾批量写**：写每日日志+项目日志用一次调用（action=add 且 entries 数组含 target=daily 与 target=project 两项，entries 仅支持这两轨），不要分成两次调用。**情绪反馈**：若本回合真人用户输入有明显情绪（正面如"太好了/谢谢"，负面如"怎么还没改对/再试一次"），给 daily 和 project 两条都带 feedback 参数（sentiment/category/quote/note，程序自动生成【反馈】行并清洗特殊字符）；daily 的 category 写通用分层（如 编程/后端/数据库；分类指工作类型如 编程→前端开发→JavaScript，不是任务涉及的功能/模块名），project 的 category 写项目内分层（如 记忆模块/写入链路，按项目实际结构）；中性任务指令或其他会话 AI 发来的消息不要带 feedback。写入立即落盘，模型上下文将在下一次刷新时更新。',
+    'Read/write long-term memory (persists across sessions; visible to the model through context snapshots). target=memory stores global environment/project facts, target=user stores user facts, target=project stores the current working directory\'s project log (visible only to sessions of this project), target=key stores the current project\'s critical long-term memory (auto-injected into context, visible only to this project\'s sessions; supports branches to limit git-branch visibility, default=all; **writes require user confirmation**: add enters a pending-confirmation queue and takes effect after approval; add accepts an optional summary parameter — a one-line abstract for progressive disclosure), target=daily appends today\'s log (read on demand, not injected). add appends an entry; replace rewrites an entire entry matched by a unique substring; remove deletes an entry matched by a unique substring; **archive moves an entry into the archive (memory/user/key tracks only)**: matched by a unique substring, removed from the main track and appended verbatim into the archive file (MEMORY-archive.md / USER-archive.md / project KEY-archive.md; reversible — the Memory tab archive page can move entries back); good for low-frequency items "no longer worth injecting but too valuable to drop". list queries entries — main track by default (unarchived; everything returned, time ascending), supporting filter (keyword), since/until (date range YYYY-MM-DD; daily may query across historical files), limit (max entries, combine with recent to fetch the latest N), recent (newest first), branch (key track: only entries visible to that branch), **archived=true (query the archive files MEMORY-archive.md / USER-archive.md / project KEY-archive.md instead — memory/user/key tracks only; key needs the session working directory; archives are not injected and can be moved back to the main track)**; when nothing matches or dates fail to parse, retry without filters. **expand loads full text on demand (progressive disclosure)**: when the key track runs in summary mode the system prompt injects only summaries; use expand+id to load the full entry. **End-of-turn batch write**: write the daily log + project log in ONE call (action=add with an entries array containing target=daily and target=project items; entries supports these two tracks only) instead of two calls. **Sentiment feedback**: when the human user\'s input this turn carries clear emotion (positive e.g. "great/thanks", negative e.g. "still wrong/try again"), attach the feedback parameter (sentiment/category/quote/note; the program renders the [Feedback] line and strips special characters) to BOTH daily and project items; daily categories use generic layering (e.g. Coding/Backend/Databases — category describes the kind of work like Coding→Frontend→JavaScript, never the feature/module name), project categories use this project\'s own layering (e.g. Memory module/write path, following actual project structure); do not attach feedback for neutral task instructions or messages from other session AIs. Writes persist immediately; model context refreshes on the next turn.',
+  ],
+  // ── parameter descriptions ──
+  'param.action': ['要执行的操作', 'The action to perform'],
+  'param.target': [
+    '记忆轨：memory=全局环境/项目事实，user=用户事实，project=当前项目日志，key=当前项目关键长期记忆（自动注入），daily=今日日志；archive 与 archived 查询只支持 memory/user/key',
+    'Memory track: memory=global environment/project facts, user=user profile facts, project=current project log, key=current project critical long-term memory (auto-injected), daily=today\'s log; archive and archived queries support memory/user/key only',
+  ],
+  'param.content': [
+    'add/replace 的新条目内容（可多行）',
+    'New entry content for add/replace (multi-line allowed)',
+  ],
+  'param.entries': [
+    'add 可选：一次调用多轨批量写入（每轮收尾合并写 daily+project 用，省一次工具往返）。每项 {target, content, feedback?}；**仅支持 daily/project 两轨**（其他轨请用单轨参数，避免绕过全局轨门禁）；传了 entries 时忽略顶层 target/content，逐项执行并返回每轨结果',
+    'Optional for add: batch-write multiple tracks in ONE call (the end-of-turn combined daily+project write saves a round trip). Each item is {target, content, feedback?}; **daily/project tracks only** (use single-track parameters for other tracks to respect global-track gating); when entries is given the top-level target/content are ignored, each item executes and returns its own result',
+  ],
+  'param.entriesTarget': [
+    '记忆轨：仅 daily（今日日志）或 project（当前项目日志）',
+    'Memory track: daily (today\'s log) or project (current project log) only',
+  ],
+  'param.entriesContent': ['条目内容（同顶层 content）', 'Entry content (same as top-level content)'],
+  'param.feedback': [
+    'add 可选（仅 daily/project 轨生效）：本回合真人用户输入有明显情绪时附带，程序自动在条目末尾拼接【反馈】行（格式固定可检索，特殊字符自动清洗）；中性任务指令或其他会话 AI 消息不要带',
+    'Optional for add (daily/project tracks only): attach when the human user\'s input this turn carries clear emotion; the program appends a [Feedback] line to the entry (fixed searchable format, special characters sanitized); skip it for neutral task instructions or messages from other session AIs',
+  ],
+  'param.sentiment': [
+    '情绪：positive=正面（太好啦/谢谢/不错），negative=负面（怎么还没改对/又错了/再试一次）；仅真人用户明确评价时给，程序会清洗特殊字符',
+    'Sentiment: positive (great/thanks/nice), negative (still wrong/wrong again/try again); provide only for explicit human-user evaluations; special characters are sanitized',
+  ],
+  'param.category': [
+    '任务分类：daily 轨写通用分层（如 编程/后端/数据库，至少一级可到三级；一级参考：编程/文档/运维/数据分析/设计/通用；分类指工作类型如 编程→前端开发→JavaScript，不是任务涉及的功能/模块名）；project 轨写本项目内分层（如 记忆模块/写入链路，按项目实际结构，不强制层级数）',
+    'Task category: daily track uses generic layering (e.g. Coding/Backend/Databases, one to three levels; top-level references: Coding/Docs/Ops/Data analysis/Design/General; category means the KIND of work like Coding→Frontend→JavaScript, never the feature/module name); project track uses this project\'s own layering (e.g. Memory module/write path, following actual structure; depth not enforced)',
+  ],
+  'param.quote': [
+    '用户原话摘录（程序自动截断 ≤20 字并清洗；情绪判定的可溯源证据）',
+    'Verbatim user quote (truncated to 20 chars and sanitized; traceable evidence for the sentiment call)',
+  ],
+  'param.note': [
+    '表现一句话（好/不好 + 原因，如 改了两轮还没对）',
+    'One-line performance note (good/bad + reason, e.g. two fix rounds still failing)',
+  ],
+  'param.manual': [
+    'true=用户手动要求记录（生成【反馈·手动】前缀）；缺省=false（自动捕获）',
+    'true=user explicitly asked to record (renders the [Feedback·manual] prefix); default=false (automatic capture)',
+  ],
+  'param.match': [
+    'replace/remove/archive 的匹配片段，必须唯一命中一个条目',
+    'Substring for replace/remove/archive; must match exactly one entry',
+  ],
+  'param.archived': [
+    'list 可选：true 时查询对应归档文件（MEMORY-archive.md / USER-archive.md / 项目 KEY-archive.md），仅 memory/user/key 三轨，key 需要会话工作目录',
+    'Optional for list: true queries the archive files (MEMORY-archive.md / USER-archive.md / project KEY-archive.md) instead; memory/user/key tracks only; key needs the session working directory',
+  ],
+  'param.branches': [
+    'add 可选（仅 key 轨）：分支范围，逗号分隔（如 main,dev）；缺省=全部（所有分支可见）；留空字符串=全部',
+    'Optional for add (key track only): branch scope, comma-separated (e.g. main,dev); default=all branches visible; empty string=all',
+  ],
+  'param.branch': [
+    'list 可选（仅 key 轨）：只返回该分支可见的条目（无标记的全部条目 + 标记含该分支的条目）',
+    'Optional for list (key track only): return only entries visible to that branch (untagged entries + entries tagged with it)',
+  ],
+  'param.filter': [
+    'list 可选：只返回内容包含该关键词的条目（大小写不敏感）',
+    'Optional for list: return only entries containing this keyword (case-insensitive)',
+  ],
+  'param.since': [
+    'list 可选：起始日期 YYYY-MM-DD；daily 轨支持跨文件查询历史日志',
+    'Optional for list: start date YYYY-MM-DD; the daily track may query across historical files',
+  ],
+  'param.until': ['list 可选：结束日期 YYYY-MM-DD', 'Optional for list: end date YYYY-MM-DD'],
+  'param.limit': [
+    'list 可选：最多返回的条数（建议与 recent 搭配取最近 N 条）',
+    'Optional for list: maximum entries to return (combine with recent to fetch the latest N)',
+  ],
+  'param.recent': [
+    'list 可选：按时间倒序返回（最新在前）',
+    'Optional for list: return newest first (reverse chronological)',
+  ],
+  'param.id': [
+    'expand 必填：条目身份证 ID（摘要模式注入的 [mem-xxxxxxxx] 中的 xxxxxxxx 部分）',
+    'Required for expand: the entry identity ID (the xxxxxxxx part of a [mem-xxxxxxxx] id shown in summary-mode injections)',
+  ],
+  'param.summary': [
+    'add 可选（仅 key 轨）：一句话摘要（≤120 字），用于渐进式披露时注入系统提示词；缺省=自动截取正文首行',
+    'Optional for add (key track only): a one-line summary (≤120 chars) injected by progressive disclosure; default=first line of the body',
+  ],
+  // ── execute-time messages ──
+  'msg.emptyContent': ['内容不能为空', 'Content must not be empty'],
+  'msg.emptyMatch': ['match 不能为空', 'match must not be empty'],
+  'msg.emptyEntry': ['条目不能为空', 'Entry must not be empty'],
+  'msg.missingTarget': [
+    '缺少 target（记忆轨必填；每轮收尾批量写请用 add + entries 数组）',
+    'Missing target (a memory track is required; use add + the entries array for the end-of-turn batch write)',
+  ],
+  'msg.fileUnreadableWrite': [
+    '记忆文件存在但无法读取，拒绝写入（防止清空已有记忆）',
+    'Memory file exists but cannot be read; write refused (protecting existing memories from being wiped)',
+  ],
+  'msg.fileUnreadableOp': [
+    '记忆文件存在但无法读取，拒绝操作（防止误判条目）',
+    'Memory file exists but cannot be read; operation refused (avoiding entry misjudgment)',
+  ],
+  'msg.driftGuardWrite': [
+    '拒绝写入：{file} 的内容无法通过记忆工具解析往返（可能被手工编辑或外部进程修改）。已备份到 {backup}。请先将该文件整理为规范的 § 分隔条目，再重试。',
+    'Write refused: {file} does not round-trip through the memory tool parser (hand-edited or modified by another process?). A backup was saved to {backup}. Re-format the file into canonical §-delimited entries first, then retry.',
+  ],
+  'msg.driftGuardOp': [
+    '拒绝操作：{file} 的内容无法通过记忆工具解析往返。已备份到 {backup}。请先整理文件再重试。',
+    'Operation refused: {file} does not round-trip through the memory tool parser. A backup was saved to {backup}. Reformat the file first, then retry.',
+  ],
+  'msg.added': ['已添加（{target}：{before} → {after} 条）', 'Added ({target}: {before} → {after} entries)'],
+  'msg.duplicate': ['条目已存在，未重复添加', 'Entry already exists; not added again'],
+  'msg.replaced': ['已替换条目（{target}：{count} 条不变）', 'Entry replaced ({target}: {count} entries unchanged)'],
+  'msg.removedEntry': ['已删除条目（{target}：{before} → {after} 条）', 'Entry deleted ({target}: {before} → {after} entries)'],
+  'msg.noMatchEntries': ['没有条目包含片段 "{match}"', 'No entry contains the substring "{match}"'],
+  'msg.multiMatch': [
+    '片段 "{match}" 匹配到 {count} 个条目，请用更精确的片段',
+    'The substring "{match}" matches {count} entries; use a more precise substring',
+  ],
+  'msg.archivedQueryOnly': [
+    'archived 查询只支持 memory / user / key（project/daily 不归档）',
+    'archived queries support memory / user / key only (project/daily are never archived)',
+  ],
+  'msg.keyArchiveNeedsCwd': ['key 归档查询需要会话工作目录', 'key archive queries need the session working directory'],
+  'msg.archiveList': [
+    '{target} 归档：{count} 条（归档不注入；需要时可移回主记忆）',
+    '{target} archive: {count} entries (archives are not injected; entries can be moved back to the main track when needed)',
+  ],
+  'msg.listMatched': ['{target}：{count} 条匹配', '{target}: {count} entries matched'],
+  'msg.protectedView': [
+    '（该轨共 {total} 条，时间跨度 {earliest} ~ {latest}，默认只返回最近 50 条——查询更早记录请加 since/until（如 since={sample}）或增大 limit）',
+    '(this track holds {total} entries spanning {earliest} ~ {latest}; by default only the latest 50 return — add since/until (e.g. since={sample}) or raise limit to reach older records)',
+  ],
+  'msg.noMatchesRetry': [
+    '（未找到匹配条目——可去掉过滤条件重新 list 读取全文核对）',
+    '(no matching entries — retry list without filters to scan the full text)',
+  ],
+  'msg.undatedSkipped': [
+    '（另有 {count} 条日期无法解析的条目未参与日期过滤——可去掉 since/until 重新 list 读取全文核对）',
+    '({count} additional entries have unparsable dates and were skipped by the date filter — retry without since/until to scan the full text)',
+  ],
+  'msg.subagentGlobalDenied': [
+    '子代理写入全局记忆被拒绝：请改用 {suggestTool} 提出建议（项目记忆与每日日志可直接写入）',
+    'Subagent writes to global memory are refused: propose via {suggestTool} instead (project memory and today\'s log stay directly writable)',
+  ],
+  'msg.approvalUnavailable': [
+    '记忆写入需要用户批准，但当前没有可用的批准通道',
+    'This memory write needs user approval but no approval channel is available',
+  ],
+  'msg.approvalReason': ['记忆审查建议写入长期记忆', 'Review suggestion writing into long-term memory'],
+  'msg.notApproved': ['记忆写入未获批准（{outcome}）', 'Memory write was not approved ({outcome})'],
+  'msg.keySuggestionQueued': [
+    '已提交待确认的项目关键记忆建议（队列 {queued} 条）——用户确认后才会写入并注入',
+    'Submitted a pending project-key-memory suggestion (queue now holds {queued}) — it is written and injected only after user confirmation',
+  ],
+  'msg.keySuggestReason': ['每轮收尾自动提交的项目关键记忆建议', 'Project key-memory suggestion auto-submitted at end of turn'],
+  'msg.writeError': [
+    '写入异常：{detail}',
+    'Write failed: {detail}',
+  ],
+  'msg.batchUnsupportedTrack': [
+    'entries 仅支持 daily/project 轨（其他轨请用单轨参数）',
+    'entries supports daily/project tracks only (use single-track parameters for other tracks)',
+  ],
+  'msg.batchSummary': [
+    '批量写入 {count} 轨：',
+    'Batch-wrote {count} tracks: ',
+  ],
+  'msg.ok': ['成功', 'ok'],
+  'msg.failed': ['失败', 'failed'],
+  'msg.archiveTracksOnly': [
+    'archive 只支持 memory / user / key 三个归档轨（project/daily 不归档）',
+    'archive supports the three archive tracks memory / user / key only (project/daily are never archived)',
+  ],
+  'msg.archiveEmptyMatch': [
+    'match 不能为空（要归档条目的唯一片段）',
+    'match must not be empty (a unique substring of the entry to archive)',
+  ],
+  'msg.archiveKeyNeedsCwd': ['key 轨归档需要会话工作目录', 'key-track archiving needs the session working directory'],
+  'msg.archiveAppendFailed': [
+    '归档写入失败：{detail}（主轨条目未动，可重试）',
+    'Archive write failed: {detail} (the main-track entry is untouched; retry is safe)',
+  ],
+  'msg.archivePartial': [
+    '已写入归档（现有 {total} 条）但主轨删除失败：{detail}——归档里多出的那条可在记忆 Tab 归档页手动清理',
+    'Archived ({total} entries now in the archive) but main-track deletion failed: {detail} — clean up the extra archive copy on the Memory tab archive page',
+  ],
+  'msg.archivedDone': [
+    '已归档（{target}：归档文件现有 {total} 条；原条目已从主轨移除，可随时在记忆 Tab 归档页移回）',
+    'Archived ({target}: the archive file now holds {total}; the original entry left the main track and can move back any time from the Memory tab archive page)',
+  ],
+  'msg.expandKeyOnly': ['expand 仅支持 target=key', 'expand supports target=key only'],
+  'msg.expandNeedsId': ['expand 需要提供 id 参数', 'expand needs the id parameter'],
+  'msg.expandNeedsCwd': ['expand 需要会话工作目录', 'expand needs the session working directory'],
+  'msg.expandNotFound': ['未找到 id={id} 的 key 条目', 'No key entry with id={id} found'],
+  'msg.expandFullText': ['条目全文', 'Entry full text'],
+  'msg.unknownAction': [
+    '未知操作 "{action}"（支持 add / replace / remove / archive / list / expand）',
+    'Unknown action "{action}" (supported: add / replace / remove / archive / list / expand)',
+  ],
+  'msg.branchWarningUnknown': [
+    '（警告：分支 {branches} 当前不存在，条目将仅在这些分支创建后可见）',
+    '(warning: branch(es) {branches} do not exist yet; entries become visible only after those branches are created)',
+  ],
+  'msg.sectionContainsDelimiter': [
+    '内容不能包含条目分隔符 §（会破坏记忆文件的分割格式）',
+    'Content must not contain the entry delimiter § (it would corrupt the memory file format)',
+  ],
+  // ── renderMemoryResult ──
+  'render.currentEntries': ['当前条目（{count} 条）：', 'Current entries ({count}):'],
+  'render.matches': ['命中的条目：', 'Matched entries:'],
+  'render.batchResults': ['批量写入结果：', 'Batch write results:'],
+  // ── feedback line ──
+  'feedback.tag': ['【反馈】', '[Feedback]'],
+  'feedback.tagManual': ['【反馈·手动】', '[Feedback·manual]'],
+  'feedback.positive': ['正面', 'positive'],
+  'feedback.negative': ['负面', 'negative'],
+  'feedback.uncategorized': ['未分类', 'Uncategorized'],
+  'feedback.sentiment': ['情绪', 'sentiment'],
+  'feedback.category': ['分类', 'category'],
+  'feedback.quote': ['原话', 'quote'],
+  'feedback.note': ['表现', 'note'],
+}
+
+/** Suggest/review-status tool strings (lib/review.js). */
+export const REVIEW_DICT = {
+  'reviewStatus.desc': [
+    '完成每 N 个用户回合的自动记忆审查。**无需每轮调用**：到期提醒由程序在快照中动态注入（出现「记忆审查已到期」提醒时才需要执行审查）；complete：审查全部执行完毕后调用，复位计数（漏做则下一轮继续提醒）；check：仅在你需要手动确认当前进度时调用（返回 due 与距上次审查的回合数）。',
+    'Completes the automatic memory review due every N user turns. **Do NOT call it every turn**: the due reminder is injected into the snapshot dynamically (run a review only when the "memory review is due" reminder appears); complete: call after finishing the whole review to reset the counter (skipping keeps the reminder coming next turn); check: call only to manually confirm current progress (returns due and turns since the last review).',
+  ],
+  'reviewStatus.action': [
+    'check=查询审查是否到期；complete=完成审查后复位计数',
+    'check=query whether a review is due; complete=reset the counter after finishing a review',
+  ],
+  'reviewStatus.notDue': [
+    '审查未到期（{turns}/{interval}），无需复位，计数保持不变。',
+    'No review is due yet ({turns}/{interval}); no reset needed and the counter stays unchanged.',
+  ],
+  'reviewStatus.reset': [
+    '审查计数已复位（下次到期按新间隔重新计数）。',
+    'Review counter reset (the next due date counts against the new interval).',
+  ],
+  'reviewStatus.due': [
+    '记忆审查已到期（距上次审查 {turns} 个回合，间隔 {interval}）：执行审查，完成后必须调用 complete 复位。',
+    'A memory review is due ({turns} turns since the last one, interval {interval}): run the review, then call complete to reset.',
+  ],
+  'reviewStatus.notDueYet': [
+    '记忆审查未到期（距上次审查 {turns}/{interval} 个回合），本轮无需审查（也不要调用 complete）。',
+    'No memory review is due ({turns}/{interval} turns since the last one); skip reviewing this turn (and do not call complete).',
+  ],
+  'suggest.desc': [
+    '提出一条长期记忆建议（记忆审查使用）。不会直接修改记忆，只会加入待用户确认的队列；重复内容会累计建议次数。',
+    'Propose one long-term-memory suggestion (used by the review flow). It never modifies memory directly — the proposal joins a queue awaiting user confirmation; repeated content accumulates a hit count.',
+  ],
+  'suggest.target': [
+    '轨：memory=环境/项目事实，user=用户事实；todo-life/todo-work/todo-project/todo-daily=待办建议（确认后写入对应待办轨）',
+    'Track: memory=environment/project facts, user=user facts; todo-life/todo-work/todo-project/todo-daily=todo suggestions (written into the matching todo track after confirmation)',
+  ],
+  'suggest.content': ['建议记忆的条目内容（可多行）', 'Suggested memory entry content (multi-line allowed)'],
+  'suggest.reason': ['为什么值得记住（引用会话中的证据）', 'Why this is worth remembering (cite evidence from the session)'],
+  'suggest.invalidTarget': [
+    '无效 target "{target}"（应为 {valid}）',
+    'Invalid target "{target}" (expected one of {valid})',
+  ],
+  'suggest.emptyContent': ['content 不能为空', 'content must not be empty'],
+  'suggest.emptyReason': ['reason 不能为空（必须引用会话中的证据）', 'reason must not be empty (cite evidence from the session)'],
+  'suggest.queued': [
+    '已提交待确认建议（队列 {queued} 条）——用户确认后才会写入',
+    'Suggestion queued for confirmation (queue now holds {queued}) — written only after user approval',
+  ],
+}
+
+/** Todo tool strings (lib/todo.js). */
+export const TODO_DICT = {
+  'todo.desc': [
+    '待办管理（四轨：life 生活 / work 工作 / project 项目（按工作目录隔离）/ daily 每日）。用户口述"记住/我要做 X"时用 add 直写——**add 的 target 遵循用户说的类别**（"工作上的事"→work、"生活中的"→life、"这个项目要"→project、"今天要"→daily），用户没说才用缺省（有工作目录 project，无 cwd 用 work）。**list 默认智能视图**：只返回需要关注的未完成项（逾期/今日到期/当前项目/重要紧急，最多 8 条），看全部需显式 all=true 或筛选参数。**查过往（昨天及更早的每日待办）请一次到位：list 加 past=true 且 expired=true**——每日待办截止=当天，过往的每日待办几乎必然已过期（除非已完成），只带 past=true 会隐藏未完成的过期遗留（只能看到已完成的过往）；带齐两个参数才能看到"昨天有哪些待办、哪些没做完"。**跨项目查询**：在别的会话里查某项目的待办用 list 加 target=project 与 cwd=<该项目工作目录路径>。done/update/remove 按 id 精确操作（list 输出带 id；每日过往条目的 id 同样可操作）。模型自建待办请用 memory_suggest target=todo-*（进待确认队列），不要直接 add。',
+    'Todo management (four tracks: life / work / project (isolated per working directory) / daily). When the user says "remember / I need to do X", write it directly with add — **the add target follows the category the user names** ("work thing"→work, "personal"→life, "for this project"→project, "today"→daily); fall back to defaults only when unspecified (project when a working directory exists, otherwise work). **list defaults to a smart view**: only unfinished items needing attention (overdue/due today/current project/important-urgent, max 8); pass all=true or filters to see everything. **Querying the past (yesterday and older daily todos) needs one precise call: list with past=true AND expired=true** — daily todos expire the same day, so past unfinished ones are almost certainly expired already; past=true alone hides expired leftovers (showing only completed history); with both parameters you see "what yesterday\'s todos were and what went undone". **Cross-project queries**: inspect another project\'s todos with list + target=project + cwd=<that project\'s working directory>. done/update/remove operate precisely by id (list output includes ids; past daily-entry ids work the same way). For model-authored todos use memory_suggest target=todo-* (enters the confirmation queue); never add directly.',
+  ],
+  'todo.action': [
+    'add=新增；list=查看（默认智能视图）；done=完成；update=修改；remove=删除',
+    'add=create; list=view (smart view by default); done=complete; update=modify; remove=delete',
+  ],
+  'todo.target': [
+    'add：遵循用户说的类别（工作→work、生活→life、项目→project、每日→daily），没说才缺省（有工作目录用 project，否则 work）；list 缺省=综合四轨；done/update/remove 缺省=全轨按 id 查找',
+    'add: follow the category the user names (work→work, personal→life, project→project, today→daily), fall back to defaults only when unspecified (project with a working directory, else work); list default=composite of all four tracks; done/update/remove default=search all tracks by id',
+  ],
+  'todo.content': [
+    'add 时必填：待办内容（首行是标题，可多行写详情）；update 时=替换内容',
+    'Required for add: todo content (first line is the title; details may follow on more lines); for update=replacement content',
+  ],
+  'todo.important': ['是否重要（与 urgent 组合成四象限）', 'Whether important (combines with urgent into the four quadrants)'],
+  'todo.urgent': ['是否紧急', 'Whether urgent'],
+  'todo.quadrant': [
+    '直接指定四象限（优先于 important/urgent）：q1 重要紧急 / q2 重要不紧急 / q3 紧急不重要 / q4 不重要不紧急',
+    'Set the quadrant directly (overrides important/urgent): q1 important+urgent / q2 important+not urgent / q3 urgent+not important / q4 neither',
+  ],
+  'todo.due': ['截止日期 YYYY-MM-DD', 'Due date YYYY-MM-DD'],
+  'todo.cat': ['分类（生活/工作/学习…）', 'Category (life/work/study…)'],
+  'todo.status': [
+    'list 筛选（缺省=智能视图）；update 设置新状态',
+    'list filter (default=smart view); update sets the new status',
+  ],
+  'todo.id': [
+    '条目标识（list 返回，如 a1b2c3d4）；done/update/remove 必填',
+    'Item id as returned by list (e.g. a1b2c3d4); required for done/update/remove',
+  ],
+  'todo.date': [
+    'daily 轨指定日期 YYYY-MM-DD（缺省=今天）',
+    'Date for the daily track YYYY-MM-DD (default=today)',
+  ],
+  'todo.all': [
+    'list 时 true=显示全部未过滤（默认智能视图）',
+    'For list: true shows everything unfiltered (smart view is the default)',
+  ],
+  'todo.past': [
+    'list 时 true=同时查询每日待办的过往（昨天及更早的历史条目，带日期）；**查过往请同时带 expired=true**（每日待办截止=当天，未完成的过往必然已过期，默认被隐藏）',
+    'For list: true also queries past daily todos (yesterday and older, with dates); **pair it with expired=true** — daily todos expire same-day, so unfinished past ones are always expired and hidden by default',
+  ],
+  'todo.expired': [
+    'list 时 true=过往中同时包含已过期的遗留条目（仅与 past=true 配合生效；缺省隐藏已过期且无未来截止的遗留）',
+    'For list: true includes expired leftover entries among the past (only takes effect with past=true; expired items without a future due date are hidden by default)',
+  ],
+  'todo.cwd': [
+    'list 时指定项目工作目录路径（跨项目查询：在别的会话里查该项目 target=project 的待办，project 轨按此路径定位；缺省=当前会话工作目录）',
+    'Working directory path for list (cross-project queries: inspect another project\'s target=project todos; the project track locates data by this path; default=current session working directory)',
+  ],
+}
+
+/** Skill-management tool strings (lib/skills.js). */
+export const SKILL_DICT = {
+  'skill.desc': [
+    '管理技能库（默认目录 ~/.agents/skills，DSH 技能库）：create 创建新技能（body 为完整 SKILL.md，含 --- frontmatter：name 与 description 单行必填）；patch 更新已有技能（必须先用 read 读取过，body 为完整修订版）；read 读取技能全文；list 列出已有技能。技能命名必须 kebab-case 类级名称（如 systematic-debugging），禁止一次性任务名。',
+    'Manage the skill library (default directory ~/.agents/skills, the DSH skill store): create adds a new skill (body is a full SKILL.md including --- frontmatter with single-line name and description); patch updates an existing skill (read it first; body is the full revised version); read returns a skill\'s full text; list enumerates skills. Skill names must be kebab-case class-like names (e.g. systematic-debugging); one-off task names are rejected.',
+  ],
+  'skill.action': ['要执行的操作', 'The action to perform'],
+  'skill.name': ['技能名（kebab-case 小写）', 'Skill name (lowercase kebab-case)'],
+  'skill.description': ['create 时的一句话描述（说明何时使用该技能，将写入 frontmatter）', 'One-sentence description for create (when to use the skill; written into frontmatter)'],
+  'skill.body': [
+    'create/patch 时的完整 SKILL.md 内容（--- frontmatter + 正文：概览/步骤/命令/坑/验证）',
+    'Full SKILL.md content for create/patch (--- frontmatter + body: overview/steps/commands/pitfalls/verification)',
+  ],
+  'skill.invalidName': [
+    '无效技能名 "{name}"（必须 kebab-case 小写，如 systematic-debugging）',
+    'Invalid skill name "{name}" (must be lowercase kebab-case, e.g. systematic-debugging)',
+  ],
+  'skill.emptyDescription': ['description 不能为空', 'description must not be empty'],
+  'skill.emptyBody': ['body 不能为空（完整 SKILL.md 内容，含 frontmatter）', 'body must not be empty (full SKILL.md content including frontmatter)'],
+  'skill.tooLarge': ['SKILL.md 超过大小上限 {limit} 字节', 'SKILL.md exceeds the size cap of {limit} bytes'],
+  'skill.badFrontmatter': [
+    'body 不是规范 SKILL.md：必须以 --- 开头的 frontmatter（含单行 name 与 description），后接正文。注意 description 请用双引号包裹（如 description: "..."），未加引号且含冒号+空格的值会被 YAML 拒绝',
+    'body is not a valid SKILL.md: it must start with a --- frontmatter block (single-line name and description) followed by the body. Quote the description value with double quotes (description: "..."); unquoted values containing colon+space get rejected by YAML',
+  ],
+  'skill.nameMismatch': [
+    'frontmatter 的 name（{parsed}）必须与技能名一致（{name}）',
+    'frontmatter name ({parsed}) must equal the skill name ({name})',
+  ],
+  'skill.descriptionMismatch': [
+    'frontmatter 的 description 与传入的 description 不一致',
+    'frontmatter description differs from the description argument',
+  ],
+  'skill.disabledShadow': [
+    '技能 "{name}" 已被禁用（modelInvocable: false），不执行写入',
+    'Skill "{name}" is disabled (modelInvocable: false); no write performed',
+  ],
+}
+
+/** Snapshot injection strings (renderSnapshot / buildMemoryContext in lib/index.js). */
+export const SNAPSHOT_DICT = {
+  'snap.sessionNamed': [
+    '## 你的会话（用名称/别名/ID 与各模块消息里的 session id 比对判断是谁；回复时把名称/别名与 ID 告知对方）',
+    '## Your session (match the name/alias/ID against session ids inside module messages to tell who is who; when replying, tell the other party the name/alias and ID)',
+  ],
+  'snap.yourName': ['- 你的会话名称：{title}', '- Your session name: {title}'],
+  'snap.yourAlias': ['- 你的会话别名：{alias}', '- Your session alias: {alias}'],
+  'snap.yourId': ['- 你的会话 ID：{id}', '- Your session ID: {id}'],
+  'snap.sessionPlain': [
+    '## 你的会话 ID（记住它：用它与各模块消息里的 session id 比对判断是谁；回复时也可把此 ID 告知对方）',
+    '## Your session ID (remember it: match it against session ids inside module messages to tell who is who; you may also give this ID to the other party when replying)',
+  ],
+  'snap.memoryHead': [
+    '## 长期记忆（所有项目、会话都必须遵循）',
+    '## Long-term memory (every project and session must follow this)',
+  ],
+  'snap.userHead': ['## 用户档案', '## User profile'],
+  'snap.keyHead': ['## 本项目关键记忆（memory 工具 target=key）', '## This project\'s key memories (memory tool target=key)'],
+  'snap.keyBranchHead': [
+    '## 本项目关键记忆（memory 工具 target=key；当前分支：{branch}，仅注入匹配分支的条目）',
+    '## This project\'s key memories (memory tool target=key; current branch: {branch}; only branch-matching entries injected)',
+  ],
+  'snap.keySummaryHead': [
+    '## 本项目关键记忆（memory 工具 target=key；摘要模式，用 memory action=expand+id 加载全文）',
+    '## This project\'s key memories (memory tool target=key; summary mode — use memory action=expand+id to load full text)',
+  ],
+  'snap.keySummaryBranchHead': [
+    '## 本项目关键记忆（memory 工具 target=key；摘要模式，当前分支：{branch}；用 memory action=expand+id 加载全文）',
+    '## This project\'s key memories (memory tool target=key; summary mode, current branch: {branch}; use memory action=expand+id to load full text)',
+  ],
+  'snap.section': [
+    '## 记忆 memory-evolve（包含 memory 工具、dtodo 待办工具、skill_manage 技能工具）',
+    '## Memory memory-evolve (provides the memory tool, dtodo todo tool, and skill_manage skill tool)',
+  ],
+  'snap.readHint': [
+    '- 读取：需要时用 memory 工具读取 target=project（项目约定/进展）与 target=daily（今日日志），不要凭猜测回答。本项目关键记忆（target=key）已注入上下文，无需读取。',
+    '- Reading: when needed use the memory tool to read target=project (project conventions/progress) and target=daily (today\'s log); never answer from guesswork. This project\'s key memories (target=key) are already injected into context — no need to re-read.',
+  ],
+  'snap.branchHint': [
+    '\n- 当前 git 分支：**{branch}**（target=key 的记忆按分支过滤注入；写 key 时可用 branches=分支名 限定范围，缺省=全部）',
+    '\n- Current git branch: **{branch}** (target=key memories are filtered by branch on injection; when writing key entries you may scope them with branches=<branch name>; default=all)',
+  ],
+  'snap.todoHint': [
+    '- 待办（dtodo）：收尾时调用 dtodo list 检查到期（默认视图：今日到期/逾期优先，最多 8 条）——有到期未完成项就在回复末尾提醒用户；不要主动展开全部待办清单，除非用户询问；用法细节（target 归类、过往/过期查询等）见 dtodo 工具描述。',
+    '- Todos (dtodo): at turn end call dtodo list to check what is due (default view: due-today/overdue first, max 8 items) — if unfinished due items exist, remind the user at the end of your reply; never expand the whole todo list unprompted; usage details (target categories, past/expired queries) live in the dtodo tool description.',
+  ],
+  'snap.turnEndHead': [
+    '- 每轮收尾（先输出完整回复文本，再在文本之后附带工具调用，严禁先调工具）必须：',
+    '- End of every turn (output your complete reply text FIRST, then attach tool calls AFTER it; calling tools first is strictly forbidden), you must:',
+  ],
+  'snap.subagentTurnEndHead': [
+    '- 收尾（先输出完整回复文本，再在文本之后附带工具调用，严禁先调工具）：',
+    '- Turn end (output your complete reply text FIRST, then attach tool calls AFTER it; calling tools first is strictly forbidden):',
+  ],
+  'snap.subagentWrite': [
+    '仅在完成**独立成果**时（一项实质产出、一个关键决策或踩坑结论），用 memory 工具一次调用（entries 数组）向 {targets} 写入 1 条，保持简洁',
+    'Only after completing an **independent achievement** (a substantive deliverable, a key decision, or a pitfall conclusion), write ONE concise entry to {targets} with a single memory call (entries array)',
+  ],
+  'snap.subagentKeyTail': [
+    '；重要结论可另向 target=key 提交建议（用户确认后生效）；没有独立成果就跳过，不要为写而写。',
+    '; for important conclusions you may additionally submit a suggestion to target=key (takes effect after user confirmation); skip entirely when there is no independent achievement — do not write for writing\'s sake.',
+  ],
+  'snap.subagentSkipTail': [
+    '；没有独立成果就跳过，不要为写而写。',
+    '; skip entirely when there is no independent achievement — do not write for writing\'s sake.',
+  ],
+  'snap.batchWriteDuty': [
+    '用 memory 工具**一次调用**（action=add + entries 数组，含 {targets} 各一项）写 1 条本回合进展（1-2 行具体内容）',
+    'In ONE memory call (action=add with an entries array containing one item each for {targets}) write one entry of this turn\'s progress (1-2 concrete lines)',
+  ],
+  'snap.and': [' 与 ', ' and '],
+  'snap.keyDuty': [
+    '本轮出现重要项目事实（长期约定/决策/架构/踩坑）时另向 target=key 提交 1 条建议（用户确认后写入并注入），没有则跳过',
+    'when durable project facts appear this turn (long-lived conventions/decisions/architecture/pitfalls), additionally submit one suggestion to target=key (written and injected after user confirmation); skip when there are none',
+  ],
+  'snap.feedbackDuty': [
+    '本回合真人用户输入有明显情绪（正面/负面）时，各条目带 feedback 参数（sentiment/category/quote/note，程序自动生成【反馈】行）——daily 的 category 写通用分类（如 编程/后端/数据库，至少一级可到三级；分类指工作类型如 编程→前端开发→JavaScript，不是任务涉及的功能/模块名），project 的 category 写本项目内分层（如 记忆模块/写入链路，按项目实际结构）；中性任务指令或其他会话 AI 消息不带 feedback',
+    'when the human user\'s input this turn carries clear emotion (positive/negative), attach the feedback parameter to both entries (sentiment/category/quote/note; the program renders a [Feedback] line) — daily categories use generic layering (e.g. Coding/Backend/Databases, one to three levels; category means the kind of work like Coding→Frontend→JavaScript, never the feature/module name), project categories use this project\'s own layering (e.g. Memory module/write path, following actual structure); no feedback for neutral task instructions or messages from other session AIs',
+  ],
+  'snap.writeStep': ['1. 写入：{duties}；', '1. Write: {duties};'],
+  'snap.reviewStep': [
+    '{n}. 审查：仅当快照出现「记忆审查已到期」提醒时执行审查（全局记忆用 memory_suggest 提建议 / mode=auto 直接写 memory，技能用 skill_manage 创建/优化），完成后调用 memory_review_status（action=complete）复位；无提醒则跳过，不要调用 check。',
+    '{n}. Review: only when the snapshot shows the "memory review is due" reminder run a review (global memory via memory_suggest suggestions / direct memory writes in mode=auto; skills via skill_manage create/patch), then call memory_review_status (action=complete) to reset; with no reminder skip — do not call check.',
+  ],
+  'snap.noTimestampTail': [
+    '- 内容不要自带时间/日期前缀（程序自动盖时间戳）。',
+    '- Do not prefix entry content with your own time/date stamps (the program timestamps automatically).',
+  ],
+  'snap.dueWarning': [
+    '\n\n⚠️ **记忆审查已到期**（间隔 {interval} 轮，mode={mode}）：本回合收尾必须执行审查——全局记忆用 memory_suggest 提交建议（mode=auto 时用 memory 直接写入），技能用 skill_manage 创建/优化；完成后调用 memory_review_status（action=complete）复位。',
+    '\n\n⚠️ **A memory review is DUE** (interval {interval} turns, mode={mode}): finish this turn by running the review — global memory via memory_suggest suggestions (direct memory writes in mode=auto), skills via skill_manage create/patch; then call memory_review_status (action=complete) to reset.',
+  ],
+  // buildMemoryContext (external-executor injections)
+  'ctx.memoryGlobal': ['【长期记忆（全局）】', '[Long-term memory (global)]'],
+  'ctx.userProfile': ['【用户档案】', '[User profile]'],
+  'ctx.keyWithBranch': ['【本项目关键记忆（分支 {branch}）】', "[This project's key memories (branch {branch})]"],
+  'ctx.keyPlain': ["【本项目关键记忆】", "[This project's key memories]"],
+}
+
+/** MemoryStore user-facing result messages (lib/store.js). */
+export const STORE_DICT = {
+  'store.emptyContent': ['内容不能为空', 'Content must not be empty'],
+  'store.emptyMatch': ['match 不能为空', 'match must not be empty'],
+  'store.fileUnreadableWrite': [
+    '记忆文件存在但无法读取，拒绝写入（防止清空已有记忆）',
+    'Memory file exists but cannot be read; write refused (protecting existing memories from being wiped)',
+  ],
+  'store.duplicate': ['条目已存在，未重复添加', 'Entry already exists; not added again'],
+  'store.added': ['已添加（{target}：{before} → {after} 条）', 'Added ({target}: {before} → {after} entries)'],
+  'store.emptyNewContent': [
+    'content 不能为空（删除条目请用 remove）',
+    'content must not be empty (use remove to delete an entry)',
+  ],
+  'store.driftGuardWrite': [
+    '拒绝写入：{file} 的内容无法通过记忆工具解析往返（可能被手工编辑或外部进程修改）。已备份到 {backup}。请先将该文件整理为规范的 § 分隔条目，再重试。',
+    'Write refused: {file} does not round-trip through the memory tool parser (hand-edited or modified by another process?). A backup was saved to {backup}. Re-format the file into canonical §-delimited entries first, then retry.',
+  ],
+  'store.noMatch': ['没有条目包含片段 "{match}"', 'No entry contains the substring "{match}"'],
+  'store.multiMatch': [
+    '片段 "{match}" 匹配到 {count} 个条目，请用更精确的片段',
+    'The substring "{match}" matches {count} entries; use a more precise substring',
+  ],
+  'store.replaced': ['已替换条目（{target}：{count} 条不变）', 'Entry replaced ({target}: {count} entries unchanged)'],
+  'store.driftGuardOp': [
+    '拒绝操作：{file} 的内容无法通过记忆工具解析往返。已备份到 {backup}。请先整理文件再重试。',
+    'Operation refused: {file} does not round-trip through the memory tool parser. A backup was saved to {backup}. Reformat the file first, then retry.',
+  ],
+  'store.fileUnreadableOp': [
+    '记忆文件存在但无法读取，拒绝操作（防止误判条目）',
+    'Memory file exists but cannot be read; operation refused (avoiding entry misjudgment)',
+  ],
+  'store.removed': ['已删除条目（{target}：{before} → {after} 条）', 'Entry deleted ({target}: {before} → {after} entries)'],
+  'store.emptyEntry': ['条目不能为空', 'Entry must not be empty'],
+  'store.sectionDelimiter': [
+    '内容不能包含条目分隔符 §（会破坏记忆文件的分割格式）',
+    'Content must not contain the entry delimiter § (it would corrupt the memory file format)',
+  ],
+}
+
+/** Store tail messages (archive helpers / manual edit paths, lib/store.js). */
+export const STORE_TAIL_DICT = {
+  'storetail.mainMissing': [
+    '主轨不存在该条目（可能已被删除）——未写入归档',
+    'The main track no longer has this entry (already deleted?) — nothing was archived',
+  ],
+  'storetail.entryMissing': [
+    '条目不存在（可能已被删除，或文件被外部修改）——请刷新列表后重试',
+    'Entry not found (deleted, or the file changed externally) — refresh the list and retry',
+  ],
+  'storetail.branchKeyOnly': ['分支范围仅适用于 key 轨', 'Branch scoping applies to the key track only'],
+  'storetail.dshOnlyTrackLimit': [
+    '「仅 DSH」标记仅适用于 memory / user / key 轨',
+    'The [dsh-only] marker applies to memory / user / key tracks only',
+  ],
+  'storetail.emptyContentTab': [
+    '内容不能为空（删除条目请用删除按钮）',
+    'Content must not be empty (use the delete button to remove an entry)',
+  ],
+  'storetail.sectionDelimiter': [
+    '内容不能包含条目分隔符 §（会破坏记忆文件的分割格式）',
+    'Content must not contain the entry delimiter § (it would corrupt the memory file format)',
+  ],
+  'storetail.unrecognizedPrefix': [
+    '该条目没有可识别的标记前缀（时间戳/tag），无法安全编辑——请用系统工具打开文件手动修改',
+    'This entry lacks a recognizable tag prefix (timestamp/tag); it cannot be edited safely — open the file with a system tool and edit it manually',
+  ],
+  'storetail.updated': ['已更新条目（{target}）', 'Entry updated ({target})'],
+  'storetail.archiveNoMatch': ['归档中没有条目包含片段 "{match}"', 'No archive entry contains the substring "{match}"'],
+  'storetail.archiveMultiMatch': [
+    '片段 "{match}" 匹配到 {count} 个归档条目，请用更精确的片段',
+    'The substring "{match}" matches {count} archive entries; use a more precise substring',
+  ],
+  'storetail.archiveEntryMissing': [
+    '归档条目不存在（可能已被删除）——请刷新列表后重试',
+    'Archive entry not found (already deleted?) — refresh the list and retry',
+  ],
+}
+
+/** Suggestion queue / review command strings (lib/review.js). */
+export const REVIEW_CMD_DICT = {
+  'reviewcmd.dedup': [
+    '该内容此前已建议（累计第 {hits} 次），已更新证据，等待用户确认',
+    'This content was proposed before (hit #{hits}); evidence updated, awaiting user confirmation',
+  ],
+  'reviewcmd.writtenMemory': ['✓ #{n} [{target}] 已写入记忆', '✓ #{n} [{target}] written into memory'],
+  'reviewcmd.writtenTodo': ['✓ #{n} [{target}] 已写入待办', '✓ #{n} [{target}] written into todos'],
+  'reviewcmd.existsSkip': ['- #{n} [{target}] 已存在，跳过', '- #{n} [{target}] already exists; skipped'],
+  'reviewcmd.failed': ['✗ #{n} [{target}] {detail}', '✗ #{n} [{target}] {detail}'],
+  'reviewcmd.remaining': ['剩余待确认：{count} 条', '{count} suggestion(s) pending confirmation'],
+  'reviewcmd.emptyQueue': ['没有待确认的记忆建议。', 'No memory suggestions are pending confirmation.'],
+  'reviewcmd.listHead': ['待确认的记忆建议（{count} 条）：', 'Memory suggestions pending confirmation ({count}):'],
+  'reviewcmd.entryLine': [
+    '{i}. [{target}] {content}（理由：{reason}）',
+    '{i}. [{target}] {content} (reason: {reason})',
+  ],
+  'reviewcmd.noReason': ['无', 'none'],
+  'reviewcmd.usageApprove': ['用法：approve <序号>…（序号来自 list）', 'Usage: approve <index>… (indices come from list)'],
+  'reviewcmd.usageArchive': ['用法：archive <序号>…（序号来自 list）', 'Usage: archive <index>… (indices come from list)'],
+  'reviewcmd.usageReject': ['用法：reject <序号>…（序号来自 list）', 'Usage: reject <index>… (indices come from list)'],
+  'reviewcmd.rejectedSome': [
+    '已拒绝 {count} 条建议。剩余待确认：{remaining} 条',
+    'Rejected {count} suggestion(s). {remaining} still pending confirmation',
+  ],
+  'reviewcmd.rejectedAll': ['已拒绝全部 {count} 条建议。', 'Rejected all {count} suggestion(s).'],
+}
+
+/** Misc host strings: sync stub commands, archive promotion, review command ops. */
+export const MISC_DICT = {
+  'misc.syncNotReady': ['记忆同步未初始化', 'Memory sync is not initialized'],
+  'misc.archiveNoMatch': [
+    '归档中没有条目包含片段 "{match}"',
+    'No archive entry contains the substring "{match}"',
+  ],
+  'misc.archiveMultiMatch': [
+    '片段 "{match}" 匹配到 {count} 个归档条目，请用更精确的片段',
+    'The substring "{match}" matches {count} archive entries; use a more precise substring',
+  ],
+  'misc.promoteEmpty': ['归档条目内容为空，无法转正', 'Archive entry content is empty; cannot promote it'],
+  'misc.promoted': [
+    '已转正写入 {target}（{chars} 字符），归档条目已移除',
+    'Promoted into {target} ({chars} chars); the archive entry was removed',
+  ],
+  'misc.unknownOp': [
+    '未知操作 "{op}"（支持：list / approve / archive / reject / approve-all / reject-all）',
+    'Unknown operation "{op}" (supported: list / approve / archive / reject / approve-all / reject-all)',
+  ],
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,12 @@ import { installBookmarks } from './bookmarks.js'
 import { installCanvas } from './canvas.js'
 import { getUpdateChecker } from './update.js'
 import { installAdvisor } from './advisor/index.js'
+import { resolveLocale, setLocale, getLocale, translate, MEMORY_DICT, REVIEW_DICT, TODO_DICT, SKILL_DICT, SNAPSHOT_DICT, MISC_DICT } from './i18n.js'
+
+/** Translate through the MEMORY dictionary in the active locale. */
+const mt = (key, params) => translate(MEMORY_DICT, key, params)
+/** Translate through the SNAPSHOT dictionary in the active locale. */
+const st = (key, params) => translate(SNAPSHOT_DICT, key, params)
 
 // Re-exported for the web API layer (api.js imports them from here).
 export { gitBranch, gitBranchList } from './store.js'
@@ -527,12 +533,12 @@ export function renderSnapshot(config, store, agent, counter, sessionTitleServic
     } catch { /* 标题读取失败置 null（兼容降级） */ }
     if (alias || title) {
       const bits = []
-      if (title) bits.push(`- 你的会话名称：${title}`)
-      if (alias) bits.push(`- 你的会话别名：${alias}`)
-      bits.push(`- 你的会话 ID：${agent.session.id}`)
-      parts.push(`## 你的会话（用名称/别名/ID 与各模块消息里的 session id 比对判断是谁；回复时把名称/别名与 ID 告知对方）\n${bits.join('\n')}`)
+      if (title) bits.push(st('snap.yourName', { title }))
+      if (alias) bits.push(st('snap.yourAlias', { alias }))
+      bits.push(st('snap.yourId', { id: agent.session.id }))
+      parts.push(`${st('snap.sessionNamed')}\n${bits.join('\n')}`)
     } else {
-      parts.push(`## 你的会话 ID（记住它：用它与各模块消息里的 session id 比对判断是谁；回复时也可把此 ID 告知对方）\n- 你的会话 ID：${agent.session.id}`)
+      parts.push(`${st('snap.sessionPlain')}\n${st('snap.yourId', { id: agent.session.id })}`)
     }
   }
   // ⚠️ 2026-08-13 设计反转：不再注入「评审员机制说明」快照段——注入消息
@@ -543,10 +549,10 @@ export function renderSnapshot(config, store, agent, counter, sessionTitleServic
   if (memoryEntries.length > 0) {
     // 展示剥离身份证（Codex 二轮 P1-4）：全局轨启用后补发的 [id:xxxx]
     // 不得进入模型上下文（与 KEY 段同规则）
-    parts.push(`## 长期记忆（所有项目、会话都必须遵循）\n${memoryEntries.map((entry) => `- ${stripEntrySummary(stripEntryId(entry))}`).join('\n')}`)
+    parts.push(`${st('snap.memoryHead')}\n${memoryEntries.map((entry) => `- ${stripEntrySummary(stripEntryId(entry))}`).join('\n')}`)
   }
   if (userEntries.length > 0) {
-    parts.push(`## 用户档案\n${userEntries.map((entry) => `- ${stripEntrySummary(stripEntryId(entry))}`).join('\n')}`)
+    parts.push(`${st('snap.userHead')}\n${userEntries.map((entry) => `- ${stripEntrySummary(stripEntryId(entry))}`).join('\n')}`)
   }
   // Project KEY facts are injected for the agent's own project only (its
   // session cwd). Same live-read/change-detected mechanism as the global
@@ -576,16 +582,16 @@ export function renderSnapshot(config, store, agent, counter, sessionTitleServic
     if (useFullInject) {
       // 全量注入（现状逻辑）
       const head = branch !== undefined
-        ? `## 本项目关键记忆（memory 工具 target=key；当前分支：${branch}，仅注入匹配分支的条目）`
-        : '## 本项目关键记忆（memory 工具 target=key）'
+        ? st('snap.keyBranchHead', { branch })
+        : st('snap.keyHead')
       // 全量注入展示剥离：身份证 [id:…] + 摘要标记 [summary:…]（2026-08-15：
       // 正文已完整，summary 是仅供摘要模式注入用的元数据，不应再显示）
       parts.push(`${head}\n${keyEntries.map((entry) => `- ${stripEntrySummary(stripEntryId(entry))}`).join('\n')}`)
     } else {
       // 摘要注入（渐进式披露）
       const head = branch !== undefined
-        ? `## 本项目关键记忆（memory 工具 target=key；摘要模式，当前分支：${branch}；用 memory action=expand+id 加载全文）`
-        : '## 本项目关键记忆（memory 工具 target=key；摘要模式，用 memory action=expand+id 加载全文）'
+        ? st('snap.keySummaryBranchHead', { branch })
+        : st('snap.keySummaryHead')
       parts.push(`${head}\n${keyEntries.map((entry) => {
         const shortId = extractEntryId(entry) ?? legacyIdFor(entry)
         const summary = parseEntrySummary(entry) || autoSummary(entry)
@@ -624,11 +630,11 @@ export function renderSnapshot(config, store, agent, counter, sessionTitleServic
   // entry matches, the branch line keeps the model branch-aware. Outside
   // git nothing branch-related is injected at all.
   const branchHint = branch !== undefined
-    ? `\n- 当前 git 分支：**${branch}**（target=key 的记忆按分支过滤注入；写 key 时可用 branches=分支名 限定范围，缺省=全部）`
+    ? st('snap.branchHint', { branch })
     : ''
-  parts.push(`## 记忆 memory-evolve（包含 memory 工具、dtodo 待办工具、skill_manage 技能工具）
-- 读取：需要时用 memory 工具读取 target=project（项目约定/进展）与 target=daily（今日日志），不要凭猜测回答。本项目关键记忆（target=key）已注入上下文，无需读取。${branchHint}
-- 待办（dtodo）：收尾时调用 dtodo list 检查到期（默认视图：今日到期/逾期优先，最多 8 条）——有到期未完成项就在回复末尾提醒用户；不要主动展开全部待办清单，除非用户询问；用法细节（target 归类、过往/过期查询等）见 dtodo 工具描述。`)
+  parts.push(`${st('snap.section')}
+${st('snap.readHint')}${branchHint}
+${st('snap.todoHint')}`)
 
   // Turn-final duties, as one minimal checklist (write → review when the
   // snapshot says so). No per-turn status check: the program injects a
@@ -641,38 +647,38 @@ export function renderSnapshot(config, store, agent, counter, sessionTitleServic
     const steps = []
     if (writeTargets.length > 0 || keyDuty) {
       if (isSubagent) {
-        const base = `仅在完成**独立成果**时（一项实质产出、一个关键决策或踩坑结论），用 memory 工具一次调用（entries 数组）向 ${writeTargets.join(' 与 ')} 写入 1 条，保持简洁`
+        const base = st('snap.subagentWrite', { targets: writeTargets.join(st('snap.and')) })
         steps.push(keyDuty
-          ? `${base}；重要结论可另向 target=key 提交建议（用户确认后生效）；没有独立成果就跳过，不要为写而写。`
-          : `${base}；没有独立成果就跳过，不要为写而写。`)
+          ? `${base}${st('snap.subagentKeyTail')}`
+          : `${base}${st('snap.subagentSkipTail')}`)
       } else {
         const duties = []
         if (writeTargets.length > 0) {
           // 一次调用批量写（entries 数组含各轨一项），省一次工具往返。
           // writeTargets 元素形如 'target=daily'，直接 join(' 与 ') 拼进提示。
-          duties.push(`用 memory 工具**一次调用**（action=add + entries 数组，含 ${writeTargets.join(' 与 ')} 各一项）写 1 条本回合进展（1-2 行具体内容）`)
+          duties.push(st('snap.batchWriteDuty', { targets: writeTargets.join(st('snap.and')) }))
         }
-        if (keyDuty) duties.push('本轮出现重要项目事实（长期约定/决策/架构/踩坑）时另向 target=key 提交 1 条建议（用户确认后写入并注入），没有则跳过')
+        if (keyDuty) duties.push(st('snap.keyDuty'))
         // 用户情绪反馈记录（2026-08-10）：真人用户本回合输入有明显情绪时，
         // 给 daily/project 条目都带 feedback 参数（程序拼接【反馈】行，格式
         // 固定可检索）；分类按轨区分：daily 通用分层、project 项目内分层。
         if (writeTargets.length > 0) {
-          duties.push('本回合真人用户输入有明显情绪（正面/负面）时，各条目带 feedback 参数（sentiment/category/quote/note，程序自动生成【反馈】行）——daily 的 category 写通用分类（如 编程/后端/数据库，至少一级可到三级；分类指工作类型如 编程→前端开发→JavaScript，不是任务涉及的功能/模块名），project 的 category 写本项目内分层（如 记忆模块/写入链路，按项目实际结构）；中性任务指令或其他会话 AI 消息不带 feedback')
+          duties.push(st('snap.feedbackDuty'))
         }
-        steps.push(`1. 写入：${duties.join('；')}；`)
+        steps.push(st('snap.writeStep', { duties: duties.join('；') }))
       }
     }
     if (reviewOn) {
       const n = steps.length + 1
-      steps.push(`${n}. 审查：仅当快照出现「记忆审查已到期」提醒时执行审查（全局记忆用 memory_suggest 提建议 / mode=auto 直接写 memory，技能用 skill_manage 创建/优化），完成后调用 memory_review_status（action=complete）复位；无提醒则跳过，不要调用 check。`)
+      steps.push(st('snap.reviewStep', { n }))
     }
-    const tail = '- 内容不要自带时间/日期前缀（程序自动盖时间戳）。'
+    const tail = st('snap.noTimestampTail')
     const dueWarning = due
-      ? `\n\n⚠️ **记忆审查已到期**（间隔 ${config.reviewInterval} 轮，mode=${config.reviewMode}）：本回合收尾必须执行审查——全局记忆用 memory_suggest 提交建议（mode=auto 时用 memory 直接写入），技能用 skill_manage 创建/优化；完成后调用 memory_review_status（action=complete）复位。`
+      ? st('snap.dueWarning', { interval: config.reviewInterval, mode: config.reviewMode })
       : ''
     const head = isSubagent
-      ? '- 收尾（先输出完整回复文本，再在文本之后附带工具调用，严禁先调工具）：'
-      : '- 每轮收尾（先输出完整回复文本，再在文本之后附带工具调用，严禁先调工具）必须：'
+      ? st('snap.subagentTurnEndHead')
+      : st('snap.turnEndHead')
     parts.push(`${head}
 ${steps.map((step) => `  ${step}`).join('\n')}
 ${tail}${dueWarning}`)
@@ -766,16 +772,16 @@ function ensureDir(path) {
 function renderMemoryResult(value) {
   const lines = [value.message ?? '']
   if (Array.isArray(value.entries) && value.entries.length > 0) {
-    lines.push(`当前条目（${value.entries.length} 条）：`)
+    lines.push(mt('render.currentEntries', { count: value.entries.length }))
     value.entries.forEach((entry, index) => lines.push(`${index + 1}. ${entry}`))
   }
   if (Array.isArray(value.matches) && value.matches.length > 0) {
-    lines.push('命中的条目：')
+    lines.push(mt('render.matches'))
     value.matches.forEach((entry, index) => lines.push(`${index + 1}. ${entry}`))
   }
   // entries 多轨批量写：逐轨渲染结果，模型一眼看清哪轨成功/失败
   if (Array.isArray(value.multi) && value.multi.length > 0) {
-    lines.push('批量写入结果：')
+    lines.push(mt('render.batchResults'))
     value.multi.forEach((m) => lines.push(`- ${m.target}: ${m.message}`))
   }
   return lines.join('\n')
@@ -824,16 +830,16 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
    */
   function buildFeedbackLine(feedback) {
     if (!feedback || typeof feedback !== 'object') return ''
-    const sent = feedback.sentiment === 'positive' ? '正面' : feedback.sentiment === 'negative' ? '负面' : null
+    const sent = feedback.sentiment === 'positive' ? mt('feedback.positive') : feedback.sentiment === 'negative' ? mt('feedback.negative') : null
     if (sent === null) return ''
     const clean = (s) => String(s ?? '').replace(/[|\n\r§"]/g, '').trim()
-    const cat = clean(feedback.category) || '未分类'
+    const cat = clean(feedback.category) || mt('feedback.uncategorized')
     const quote = clean(feedback.quote).slice(0, 20)
     const note = clean(feedback.note)
-    const tag = feedback.manual === true ? '【反馈·手动】' : '【反馈】'
-    const parts = [`情绪:${sent}`, `分类:${cat}`]
-    if (quote) parts.push(`原话:"${quote}"`)
-    if (note) parts.push(`表现:${note}`)
+    const tag = feedback.manual === true ? mt('feedback.tagManual') : mt('feedback.tag')
+    const parts = [`${mt('feedback.sentiment')}:${sent}`, `${mt('feedback.category')}:${cat}`]
+    if (quote) parts.push(`${mt('feedback.quote')}:"${quote}"`)
+    if (note) parts.push(`${mt('feedback.note')}:${note}`)
     return `${tag}${parts.join(' | ')}`
   }
 
@@ -853,7 +859,7 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
     const fbLine = target === 'daily' || target === 'project' ? buildFeedbackLine(feedback) : ''
     let finalContent = String(content ?? '').trim()
     if (fbLine !== '') finalContent = finalContent === '' ? fbLine : `${finalContent}\n${fbLine}`
-    if (finalContent === '') return { ok: false, message: '内容不能为空', target }
+    if (finalContent === '') return { ok: false, message: mt('msg.emptyContent'), target }
     // 渐进式披露：key 轨支持 summary 参数，拼入 [summary:...] 标签。
     // 清洗（审查修复）：换行会让标签跨行、']' 会让解析正则 [^\]]* 提前
     // 截断（剩余文字漏进正文、stripEntrySummary 失配）——都是 LLM 自由
@@ -866,9 +872,9 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
       }
     }
     if (target === 'key') {
-      const outcome = enqueueSuggestion(queue, 'key', finalContent, '每轮收尾自动提交的项目关键记忆建议', exec?.agent)
+      const outcome = enqueueSuggestion(queue, 'key', finalContent, mt('msg.keySuggestReason'), exec?.agent)
       if (outcome.ok) {
-        outcome.message = `已提交待确认的项目关键记忆建议（队列 ${outcome.queued} 条）——用户确认后才会写入并注入`
+        outcome.message = mt('msg.keySuggestionQueued', { queued: outcome.queued })
       }
       // queued 不在输出 schema 内（additionalProperties:false），剥离
       const { queued: _queued, ...rest } = outcome
@@ -880,27 +886,27 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
 
   return {
     name: config.toolName,
-    description: '读写长期记忆（跨会话持久，随上下文快照对模型可见）。target=memory 存全局环境/项目事实，target=user 存用户事实，target=project 存当前工作目录的项目日志（仅当前项目会话可见），target=key 存当前项目的关键长期记忆（自动注入上下文，仅当前项目会话可见；支持 branches 限定 git 分支范围，缺省=全部；**写入需用户确认**：add 会进入待确认队列，确认后生效；add 可选 summary 参数提供一句话摘要用于渐进式披露），target=daily 追加今日日志（按需读取，不注入）。add 追加条目；replace 用唯一子串片段替换整个条目；remove 用唯一子串片段删除条目；**archive 把条目归档（仅 memory/user/key 三轨）**：按唯一子串片段从主轨移除整条、原文追加进对应归档文件（MEMORY-archive.md / USER-archive.md / 项目 KEY-archive.md，可逆——记忆 Tab 归档页可移回主记忆），适合"已不再需要注入、但丢之可惜"的低频旧事；list 查询条目——默认查主轨（未归档，全部返回，按时间正序），支持 filter（关键词过滤）、since/until（日期范围 YYYY-MM-DD，daily 可跨文件查历史日志）、limit（最多条数，配合 recent 取最近 N 条）、recent（最新在前）、branch（key 轨：只返回该分支可见的条目）、**archived=true（查对应归档文件 MEMORY-archive.md / USER-archive.md / 项目 KEY-archive.md——仅 memory/user/key 三轨，key 需要会话工作目录；归档不注入，可移回主记忆）**；查不到匹配或日期无法解析时，去掉过滤条件重查。**expand 按需加载全文（渐进式披露）**：当 key 轨为摘要模式时，系统提示词只注入摘要，需要详情时用 expand+id 加载完整条目。**每轮收尾批量写**：写每日日志+项目日志用一次调用（action=add 且 entries 数组含 target=daily 与 target=project 两项，entries 仅支持这两轨），不要分成两次调用。**情绪反馈**：若本回合真人用户输入有明显情绪（正面如"太好了/谢谢"，负面如"怎么还没改对/再试一次"），给 daily 和 project 两条都带 feedback 参数（sentiment/category/quote/note，程序自动生成【反馈】行并清洗特殊字符）；daily 的 category 写通用分层（如 编程/后端/数据库；分类指工作类型如 编程→前端开发→JavaScript，不是任务涉及的功能/模块名），project 的 category 写项目内分层（如 记忆模块/写入链路，按项目实际结构）；中性任务指令或其他会话 AI 发来的消息不要带 feedback。写入立即落盘，模型上下文将在下一次刷新时更新。',
+    get description() { return mt('memory.desc') },
     parameters: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
           enum: ['add', 'replace', 'remove', 'archive', 'list', 'expand'],
-          description: '要执行的操作',
+          get description() { return mt('param.action') },
         },
         target: {
           type: 'string',
           enum: ['memory', 'user', 'project', 'key', 'daily'],
-          description: '记忆轨：memory=全局环境/项目事实，user=用户事实，project=当前项目日志，key=当前项目关键长期记忆（自动注入），daily=今日日志；archive 与 archived 查询只支持 memory/user/key',
+          get description() { return mt('param.target') },
         },
         content: {
           type: 'string',
-          description: 'add/replace 的新条目内容（可多行）',
+          get description() { return mt('param.content') },
         },
         entries: {
           type: 'array',
-          description: 'add 可选：一次调用多轨批量写入（每轮收尾合并写 daily+project 用，省一次工具往返）。每项 {target, content, feedback?}；**仅支持 daily/project 两轨**（其他轨请用单轨参数，避免绕过全局轨门禁）；传了 entries 时忽略顶层 target/content，逐项执行并返回每轨结果',
+          get description() { return mt('param.entries') },
           items: {
             type: 'object',
             additionalProperties: false,
@@ -908,11 +914,11 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
               target: {
                 type: 'string',
                 enum: ['daily', 'project'],
-                description: '记忆轨：仅 daily（今日日志）或 project（当前项目日志）',
+                get description() { return mt('param.entriesTarget') },
               },
               content: {
                 type: 'string',
-                description: '条目内容（同顶层 content）',
+                get description() { return mt('param.entriesContent') },
               },
               feedback: {
                 type: 'object',
@@ -921,27 +927,27 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
                   sentiment: {
                     type: 'string',
                     enum: ['positive', 'negative'],
-                    description: '情绪：positive=正面（太好啦/谢谢/不错），negative=负面（怎么还没改对/又错了/再试一次）；仅真人用户明确评价时给，程序会清洗特殊字符',
+                    get description() { return mt('param.sentiment') },
                   },
                   category: {
                     type: 'string',
-                    description: '任务分类：daily 轨写通用分层（如 编程/后端/数据库，至少一级可到三级；一级参考：编程/文档/运维/数据分析/设计/通用；分类指工作类型如 编程→前端开发→JavaScript，不是任务涉及的功能/模块名，模块名只属于 project 轨）；project 轨写本项目内分层（如 记忆模块/写入链路，按项目实际结构，不强制层级数）',
+                    get description() { return mt('param.category') },
                   },
                   quote: {
                     type: 'string',
-                    description: '用户原话摘录（程序自动截断 ≤20 字并清洗；情绪判定的可溯源证据）',
+                    get description() { return mt('param.quote') },
                   },
                   note: {
                     type: 'string',
-                    description: '表现一句话（好/不好 + 原因，如 改了两轮还没对）',
+                    get description() { return mt('param.note') },
                   },
                   manual: {
                     type: 'boolean',
-                    description: 'true=用户手动要求记录（生成【反馈·手动】前缀）；缺省=false（自动捕获）',
+                    get description() { return mt('param.manual') },
                   },
                 },
                 required: ['sentiment'],
-                description: 'add 可选：本回合真人用户输入有明显情绪时附带，程序自动在条目末尾拼接【反馈】行（格式固定可检索，特殊字符自动清洗）；中性任务指令或其他会话 AI 消息不要带',
+                get description() { return mt('feedback.tag') },
               },
             },
             required: ['target', 'content'],
@@ -954,71 +960,71 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
             sentiment: {
               type: 'string',
               enum: ['positive', 'negative'],
-              description: '情绪：positive=正面（太好啦/谢谢/不错），negative=负面（怎么还没改对/又错了/再试一次）；仅真人用户明确评价时给，程序会清洗特殊字符',
+              get description() { return mt('param.sentiment') },
             },
             category: {
               type: 'string',
-              description: '任务分类：daily 轨写通用分层（如 编程/后端/数据库，至少一级可到三级；一级参考：编程/文档/运维/数据分析/设计/通用）；project 轨写本项目内分层（如 记忆模块/写入链路，按项目实际结构，不强制层级数）',
+              get description() { return mt('param.category') },
             },
             quote: {
               type: 'string',
-              description: '用户原话摘录（程序自动截断 ≤20 字并清洗；情绪判定的可溯源证据）',
+              get description() { return mt('param.quote') },
             },
             note: {
               type: 'string',
-              description: '表现一句话（好/不好 + 原因，如 改了两轮还没对）',
+              get description() { return mt('param.note') },
             },
             manual: {
               type: 'boolean',
-              description: 'true=用户手动要求记录（生成【反馈·手动】前缀）；缺省=false（自动捕获）',
+              get description() { return mt('param.manual') },
             },
           },
           required: ['sentiment'],
-          description: 'add 可选（仅 daily/project 轨生效）：本回合真人用户输入有明显情绪时附带，程序自动在条目末尾拼接【反馈】行（格式固定可检索，特殊字符自动清洗）；中性任务指令或其他会话 AI 消息不要带',
+          get description() { return mt('param.feedback') },
         },
         match: {
           type: 'string',
-          description: 'replace/remove/archive 的匹配片段，必须唯一命中一个条目',
+          get description() { return mt('param.match') },
         },
         archived: {
           type: 'boolean',
-          description: 'list 可选：true 时查询对应归档文件（MEMORY-archive.md / USER-archive.md / 项目 KEY-archive.md），仅 memory/user/key 三轨，key 需要会话工作目录',
+          get description() { return mt('param.archived') },
         },
         branches: {
           type: 'string',
-          description: 'add 可选（仅 key 轨）：分支范围，逗号分隔（如 main,dev）；缺省=全部（所有分支可见）；留空字符串=全部',
+          get description() { return mt('param.branches') },
         },
         branch: {
           type: 'string',
-          description: 'list 可选（仅 key 轨）：只返回该分支可见的条目（无标记的全部条目 + 标记含该分支的条目）',
+          get description() { return mt('param.branch') },
         },
         filter: {
           type: 'string',
-          description: 'list 可选：只返回内容包含该关键词的条目（大小写不敏感）',
+          get description() { return mt('param.filter') },
         },
         since: {
           type: 'string',
-          description: 'list 可选：起始日期 YYYY-MM-DD；daily 轨支持跨文件查询历史日志',
+          get description() { return mt('param.since') },
         },
         until: {
           type: 'string',
-          description: 'list 可选：结束日期 YYYY-MM-DD',
+          get description() { return mt('param.until') },
         },
         limit: {
           type: 'integer',
-          description: 'list 可选：最多返回的条数（建议与 recent 搭配取最近 N 条）',
+          get description() { return mt('param.limit') },
         },
         recent: {
           type: 'boolean',
-          description: 'list 可选：按时间倒序返回（最新在前）',
+          get description() { return mt('param.recent') },
         },
         id: {
           type: 'string',
-          description: 'expand 必填：条目身份证 ID（摘要模式注入的 [mem-xxxxxxxx] 中的 xxxxxxxx 部分）',
+          get description() { return mt('param.id') },
         },
         summary: {
           type: 'string',
-          description: 'add 可选（仅 key 轨）：一句话摘要（≤120 字），用于渐进式披露时注入系统提示词；缺省=自动截取正文首行',
+          get description() { return mt('param.summary') },
         },
       },
       required: ['action', 'target'],
@@ -1072,13 +1078,13 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
         if (getRuntime().reviewMode !== 'auto') {
           return {
             ok: false,
-            message: `子代理写入全局记忆被拒绝：请改用 ${getRuntime().suggestToolName} 提出建议（项目记忆与每日日志可直接写入）`,
+            message: mt('msg.subagentGlobalDenied', { suggestTool: getRuntime().suggestToolName }),
             target,
           }
         }
         const approval = ctx.get('approval')
         if (!approval) {
-          return { ok: false, message: '记忆写入需要用户批准，但当前没有可用的批准通道', target }
+          return { ok: false, message: mt('msg.approvalUnavailable'), target }
         }
         const outcome = await approval.request({
           agent: exec.agent,
@@ -1088,14 +1094,14 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
           signal: exec.signal,
         })
         if (outcome !== 'allowed-once') {
-          return { ok: false, message: `记忆写入未获批准（${outcome}）`, target }
+          return { ok: false, message: mt('msg.notApproved', { outcome }), target }
         }
       }
       // target 兜底校验：required 已放宽为仅 ['action']（entries 批量模式
       // 不需要顶层 target），其他操作缺 target 时给出明确错误而非底层报错。
       const isEntriesAdd = action === 'add' && Array.isArray(args.entries) && args.entries.length > 0
       if (!target && !isEntriesAdd) {
-        return { ok: false, message: '缺少 target（记忆轨必填；每轮收尾批量写请用 add + entries 数组）' }
+        return { ok: false, message: mt('msg.missingTarget') }
       }
       let result
       try {
@@ -1106,12 +1112,12 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
             // 需要时可在这里检索（移回主记忆走记忆 Tab 或人工转正）。
             if (args.archived === true) {
               if (target !== 'memory' && target !== 'user' && target !== 'key') {
-                result = { ok: false, message: 'archived 查询只支持 memory / user / key（project/daily 不归档）', target }
+                result = { ok: false, message: mt('msg.archivedQueryOnly'), target }
                 break
               }
               const cwd = exec?.agent?.session?.header?.cwd
               if (target === 'key' && !cwd) {
-                result = { ok: false, message: 'key 归档查询需要会话工作目录', target }
+                result = { ok: false, message: mt('msg.keyArchiveNeedsCwd'), target }
                 break
               }
               let entries = archive.entriesOf(target, cwd)
@@ -1134,7 +1140,7 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
               }
               result = {
                 ok: true,
-                message: `${target} 归档：${entries.length} 条（归档不注入；需要时可移回主记忆）`,
+                message: mt('msg.archiveList', { target, count: entries.length }),
                 target,
                 entries: entries.map((entry) => stripEntrySummary(stripEntryId(entry))), // 展示剥离身份证+摘要标记（§4.7）
                 chars: entries.map((entry) => stripEntrySummary(stripEntryId(entry))).join('\n').length,
@@ -1216,11 +1222,11 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
                 const t = item?.target
                 const c = String(item?.content ?? '').trim()
                 if (t !== 'daily' && t !== 'project') {
-                  multi.push({ target: String(t ?? '?'), ok: false, message: 'entries 仅支持 daily/project 轨（其他轨请用单轨参数）' })
+                  multi.push({ target: String(t ?? '?'), ok: false, message: mt('msg.batchUnsupportedTrack') })
                   continue
                 }
                 if (c === '') {
-                  multi.push({ target: t, ok: false, message: '内容不能为空' })
+                  multi.push({ target: t, ok: false, message: mt('msg.emptyContent') })
                   continue
                 }
                 // 单轨容错（issue #18 建议第 3 条）：任何一轨写入抛异常
@@ -1230,14 +1236,14 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
                 try {
                   r = await addOne(t, c, item?.feedback, exec)
                 } catch (error) {
-                  r = { ok: false, message: `写入异常：${error?.message ?? String(error)}` }
+                  r = { ok: false, message: mt('msg.writeError', { detail: error?.message ?? String(error) }) }
                 }
                 multi.push({ target: t, ok: r.ok, message: r.message })
               }
               const allOk = multi.every((m) => m.ok)
               result = {
                 ok: allOk,
-                message: `批量写入 ${multi.length} 轨：` + multi.map((m) => `${m.target}=${m.ok ? '成功' : '失败'}`).join(' '),
+                message: mt('msg.batchSummary', { count: multi.length }) + multi.map((m) => `${m.target}=${m.ok ? mt('msg.ok') : mt('msg.failed')}`).join(' '),
                 multi,
               }
               break
@@ -1255,7 +1261,7 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
                 if (known.length > 0) {
                   const unknown = list.filter((b) => !known.includes(b))
                   if (unknown.length > 0) {
-                    branchWarning = `（警告：分支 ${unknown.join('、')} 当前不存在，条目将仅在这些分支创建后可见）`
+                    branchWarning = mt('msg.branchWarningUnknown', { branches: unknown.join(', ') })
                   }
                 }
               }
@@ -1283,17 +1289,17 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
             // 里会多出一条可手动清理的条目，但主轨数据仍在、可恢复——
             // 权衡取「宁可重复、不可丢失」。
             if (target !== 'memory' && target !== 'user' && target !== 'key') {
-              result = { ok: false, message: 'archive 只支持 memory / user / key 三个归档轨（project/daily 不归档）', target }
+              result = { ok: false, message: mt('msg.archiveTracksOnly'), target }
               break
             }
             const match = String(args.match ?? '').trim()
             if (!match) {
-              result = { ok: false, message: 'match 不能为空（要归档条目的唯一片段）', target }
+              result = { ok: false, message: mt('msg.archiveEmptyMatch'), target }
               break
             }
             const cwd = exec?.agent?.session?.header?.cwd
             if (target === 'key' && !cwd) {
-              result = { ok: false, message: 'key 轨归档需要会话工作目录', target }
+              result = { ok: false, message: mt('msg.archiveKeyNeedsCwd'), target }
               break
             }
             // 第一步：预览命中原文（只读，不写盘）
@@ -1307,7 +1313,7 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
             if (!appended.ok) {
               result = {
                 ok: false,
-                message: `归档写入失败：${appended.message ?? '未知错误'}（主轨条目未动，可重试）`,
+                message: mt('msg.archiveAppendFailed', { detail: appended.message ?? '?' }),
                 target,
               }
               break
@@ -1317,14 +1323,14 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
             if (!removed.ok) {
               result = {
                 ok: false,
-                message: `已写入归档（现有 ${appended.total} 条）但主轨删除失败：${removed.message}——归档里多出的那条可在记忆 Tab 归档页手动清理`,
+                message: mt('msg.archivePartial', { total: appended.total, detail: removed.message }),
                 target,
               }
               break
             }
             result = {
               ok: true,
-              message: `已归档（${target}：归档文件现有 ${appended.total} 条；原条目已从主轨移除，可随时在记忆 Tab 归档页移回）`,
+              message: mt('msg.archivedDone', { target, total: appended.total }),
               target,
             }
             break
@@ -1332,16 +1338,16 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
           case 'expand': {
             // 渐进式披露：按 ID 加载 key 轨条目全文
             if (target !== 'key') {
-              result = { ok: false, message: 'expand 仅支持 target=key', target }
+              result = { ok: false, message: mt('msg.expandKeyOnly'), target }
               break
             }
             if (!args.id) {
-              result = { ok: false, message: 'expand 需要提供 id 参数', target }
+              result = { ok: false, message: mt('msg.expandNeedsId'), target }
               break
             }
             const cwd = exec?.agent?.session?.header?.cwd
             if (!cwd) {
-              result = { ok: false, message: 'expand 需要会话工作目录', target }
+              result = { ok: false, message: mt('msg.expandNeedsCwd'), target }
               break
             }
             const keyAgent = { session: { header: { cwd } } }
@@ -1358,19 +1364,19 @@ export function memoryTool(ctx, config, store, queue, getRuntime, archive) {
             }
             const found = keyEntries.find(e => e.includes(`[id:${args.id}]`) || legacyIdFor(e) === args.id)
             if (!found) {
-              result = { ok: false, message: `未找到 id=${args.id} 的 key 条目`, target }
+              result = { ok: false, message: mt('msg.expandNotFound', { id: args.id }), target }
               break
             }
             result = {
               ok: true,
-              message: '条目全文',
+              message: mt('msg.expandFullText'),
               target,
               entries: [stripEntrySummary(stripEntryId(found))],
             }
             break
           }
           default:
-            result = { ok: false, message: `未知操作 "${action}"（支持 add / replace / remove / archive / list / expand）`, target }
+            result = { ok: false, message: mt('msg.unknownAction', { action }), target }
         }
       } catch (error) {
         // e.g. project memory without a session cwd
@@ -1409,11 +1415,11 @@ export function buildMemoryContext(store, { cwd, branch: declaredBranch, tracks,
   const parts = []
   if (want('memory')) {
     const memoryEntries = dshOnlySafe(store.entriesOf('memory'))
-    if (memoryEntries.length > 0) parts.push(`【长期记忆（全局）】\n${memoryEntries.join('\n')}`)
+    if (memoryEntries.length > 0) parts.push(`${st('ctx.memoryGlobal')}\n${memoryEntries.join('\n')}`)
   }
   if (want('user')) {
     const userEntries = dshOnlySafe(store.entriesOf('user'))
-    if (userEntries.length > 0) parts.push(`【用户档案】\n${userEntries.join('\n')}`)
+    if (userEntries.length > 0) parts.push(`${st('ctx.userProfile')}\n${userEntries.join('\n')}`)
   }
   if (want('key') && cwd) {
     const keyAgent = { session: { header: { cwd } } }
@@ -1430,7 +1436,7 @@ export function buildMemoryContext(store, { cwd, branch: declaredBranch, tracks,
       })
     }
     if (keyEntries.length > 0) {
-      const head = branch !== undefined ? `【本项目关键记忆（分支 ${branch}）】` : '【本项目关键记忆】'
+      const head = branch !== undefined ? st('ctx.keyWithBranch', { branch }) : st('ctx.keyPlain')
       // 展示剥离：身份证 [id:…] 不注入（审查 P1-5：COI/外部执行器出口）
       // 展示剥离：身份证 + 摘要标记（与 DSH 快照全量注入同规则；正文完整时
       // [summary:…] 是仅供摘要模式用的元数据，不注入外部执行器）
@@ -1447,6 +1453,21 @@ export function buildMemoryContext(store, { cwd, branch: declaredBranch, tracks,
  */
 export function apply(ctx, rawConfig = {}) {
   const config = resolveConfig(rawConfig)
+  // Host-side locale (English support): resolve once at boot from the DSH
+  // Language preference (default 'en' when unset), then follow live changes
+  // through the settings commit event. Getter-based tool descriptions and
+  // snapshot builders read the active locale per call, so a flip takes
+  // effect on the next model request / injected turn without re-registering
+  // anything. The 'locale' namespace belongs to DSH's own locale plugin —
+  // we only .get() it here and never write to it.
+  setLocale(resolveLocale(ctx))
+  ctx.effect(() => {
+    const settings = ctx.get('settings')
+    if (!settings || typeof settings.get !== 'function') return () => {}
+    return ctx.on('settings/updated', (ns) => {
+      if (ns === 'locale') setLocale(resolveLocale(ctx))
+    })
+  }, 'dsh-memory-evolve: locale watcher')
   const store = new MemoryStore(config.memoryDir, {
     ...config,
     // 记忆同步接线（施工图 §4.2/§6）：entryIdMode 随 syncEnabled 动态开关
@@ -1628,10 +1649,10 @@ export function apply(ctx, rawConfig = {}) {
       // 记忆同步 UI 操作（/memory_sync 命令组的 API 化：setup/sync/off/
       // resolve/conflicts/migrate——记忆同步 Tab 用）
       syncOps: syncOpsRef ?? {
-        setup: async () => ({ kind: 'error', text: '记忆同步未初始化' }),
-        sync: async () => ({ kind: 'error', text: '记忆同步未初始化' }),
-        off: () => ({ kind: 'error', text: '记忆同步未初始化' }),
-        resolve: async () => ({ kind: 'error', text: '记忆同步未初始化' }),
+        setup: async () => ({ kind: 'error', text: translate(MISC_DICT, 'misc.syncNotReady', undefined, getLocale()) }),
+        sync: async () => ({ kind: 'error', text: translate(MISC_DICT, 'misc.syncNotReady', undefined, getLocale()) }),
+        off: () => ({ kind: 'error', text: translate(MISC_DICT, 'misc.syncNotReady', undefined, getLocale()) }),
+        resolve: async () => ({ kind: 'error', text: translate(MISC_DICT, 'misc.syncNotReady', undefined, getLocale()) }),
         conflicts: () => [],
         migrate: () => null,
       },

--- a/lib/memory-tab.js
+++ b/lib/memory-tab.js
@@ -21,6 +21,24 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { resolveProjectDir } from './sync/identity.js'
 import { stripEntrySummary } from './store.js'
+import { translate, getLocale } from './i18n.js'
+
+/**
+ * Row-title dictionary (zh/en pairs) — the memory tab's file listing is
+ * host-rendered data (lib/api.js → buildMemoryFiles), so its labels localize
+ * on the host side with the active session locale instead of in the browser.
+ */
+const TITLE_DICT = {
+  'memoryTab.row.project': ['项目日志', 'Project log'],
+  'memoryTab.row.key': ['项目关键记忆 KEY.md', 'Key project facts KEY.md'],
+  'memoryTab.row.archiveKey': ['项目关键记忆归档 KEY-archive.md', 'Archived key facts KEY-archive.md'],
+  'memoryTab.row.daily': ['今日日志', 'Daily log'],
+  'memoryTab.row.user': ['用户档案 USER.md', 'User profile USER.md'],
+  'memoryTab.row.memory': ['长期记忆 MEMORY.md', 'Long-term memory MEMORY.md'],
+  'memoryTab.row.archiveUser': ['归档用户 USER-archive.md', 'Archived user profile USER-archive.md'],
+  'memoryTab.row.archiveMemory': ['归档记忆 MEMORY-archive.md', 'Archived long-term memory MEMORY-archive.md'],
+  'memoryTab.row.agents': ['全局规则 AGENTS.md', 'AGENTS.md'],
+}
 
 /**
  * 不再设显示上限（2026-08-10）：项目日志/每日日志是追加增长型文件
@@ -44,28 +62,28 @@ export function buildMemoryFiles(config, store, cwd) {
   const rows = [
     {
       key: 'project',
-      title: '项目日志',
+      title: translate(TITLE_DICT, 'memoryTab.row.project', undefined, getLocale()),
       path: projectAgent ? store.pathOf('project', projectAgent) : undefined,
       available: projectAgent !== undefined,
     },
     {
       key: 'key',
-      title: '项目关键记忆 KEY.md',
+      title: translate(TITLE_DICT, 'memoryTab.row.key', undefined, getLocale()),
       path: projectAgent ? store.pathOf('key', projectAgent) : undefined,
       available: projectAgent !== undefined,
     },
     {
       key: 'archive-key',
-      title: '项目关键记忆归档 KEY-archive.md',
+      title: translate(TITLE_DICT, 'memoryTab.row.archiveKey', undefined, getLocale()),
       path: projectDir ? join(projectDir, 'KEY-archive.md') : undefined,
       available: projectDir !== undefined,
     },
-    { key: 'daily', title: '今日日志', path: store.pathOf('daily') },
-    { key: 'user', title: '用户档案 USER.md', path: store.pathOf('user') },
-    { key: 'memory', title: '长期记忆 MEMORY.md', path: store.pathOf('memory') },
-    { key: 'archive-user', title: '归档用户 USER-archive.md', path: join(config.memoryDir, 'USER-archive.md') },
-    { key: 'archive-memory', title: '归档记忆 MEMORY-archive.md', path: join(config.memoryDir, 'MEMORY-archive.md') },
-    { key: 'agents', title: '全局规则 AGENTS.md', path: join(dshHome, 'AGENTS.md') },
+    { key: 'daily', title: translate(TITLE_DICT, 'memoryTab.row.daily', undefined, getLocale()), path: store.pathOf('daily') },
+    { key: 'user', title: translate(TITLE_DICT, 'memoryTab.row.user', undefined, getLocale()), path: store.pathOf('user') },
+    { key: 'memory', title: translate(TITLE_DICT, 'memoryTab.row.memory', undefined, getLocale()), path: store.pathOf('memory') },
+    { key: 'archive-user', title: translate(TITLE_DICT, 'memoryTab.row.archiveUser', undefined, getLocale()), path: join(config.memoryDir, 'USER-archive.md') },
+    { key: 'archive-memory', title: translate(TITLE_DICT, 'memoryTab.row.archiveMemory', undefined, getLocale()), path: join(config.memoryDir, 'MEMORY-archive.md') },
+    { key: 'agents', title: translate(TITLE_DICT, 'memoryTab.row.agents', undefined, getLocale()), path: join(dshHome, 'AGENTS.md') },
   ]
   return rows.map((row) => {
     const out = {

--- a/lib/notify-web.js
+++ b/lib/notify-web.js
@@ -27,6 +27,10 @@
  */
 import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { translate, getLocale, MISC2_DICT } from './i18n.js'
+
+/** Translate through MISC2_DICT in the active host locale. */
+const nt2 = (key, params) => translate(MISC2_DICT, key, params, getLocale())
 import { URL } from 'node:url'
 // 附件落盘 + 魔数嗅探：复用广播模块已实现的能力（path/url/base64 三选一 +
 // 魔数嗅探 + 安全文件名 + 失败清理），避免重复造轮子。广播的 resolveAttachments
@@ -225,7 +229,7 @@ export class NotificationStore {
   remove(id) {
     this.#load()
     const at = this.items.findIndex((i) => i.id === id)
-    if (at < 0) return { ok: false, message: `通知 ${id} 不存在` }
+    if (at < 0) return { ok: false, message: nt2('notify.missing', { id }) }
     const m = this.items[at]
     if (m.bodyFile) { try { rmSync(m.bodyFile, { force: true }) } catch { /* 忽略 */ } }
     for (const a of m.attachments ?? []) {

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -24,6 +24,10 @@
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { translate, getLocale, PROMPT_DICT } from './i18n.js'
+
+/** Translate through PROMPT_DICT in the active host locale. */
+const pt = (key, params) => translate(PROMPT_DICT, key, params, getLocale())
 
 /** 注入轨文件与提示词库文件（相对 memoryDir）。 */
 const INJECTIONS_FILE = 'prompt-injections.json'
@@ -665,7 +669,7 @@ function steerImmediateInjection(ctx, sessionId, promptName) {
     agent.steer({
       role: 'user',
       id: randomUUID(),
-      content: [{ type: 'text', text: `【立即注入】提示词「${promptName}」已生效（仅此一次）——请查看快照「用户规则」并立即遵循。` }],
+      content: [{ type: 'text', text: pt('promptmsg.injectedOnce', { name: promptName }) }],
       source: { kind: 'user' }, // 与 de_session followup 同款构造（id 稳定唯一，DSH 用它追踪）
     })
     return true
@@ -924,13 +928,13 @@ export function promptsToolDefinition(config, promptStore, injectionStore, ctx) 
         }
         if (action === 'get') {
           const id = String(args?.id ?? '').trim()
-          if (!id) return { ok: false, message: 'get 需要 id（来自 list 返回）', action: 'get' }
+          if (!id) return { ok: false, message: pt('promptmsg.getNeedsId'), action: 'get' }
           const p = promptStore.get(id)
-          if (!p) return { ok: false, message: `提示词不存在：${id}（可先 list 查看可用提示词）`, action: 'get' }
+          if (!p) return { ok: false, message: pt('promptmsg.missingGet', { id }), action: 'get' }
           // 详情返回全部字段（含正文/状态/统计）；禁用提示词也可查（AI 自行判断）
           return {
             ok: true,
-            message: `「${p.name}」详情（${p.enabled === false ? '已禁用' : '启用中'}，已注入 ${p.usageCount ?? 0} 次）`,
+            message: pt('promptmsg.detail', { name: p.name, status: p.enabled === false ? pt('promptmsg.disabled') : pt('promptmsg.enabled'), count: p.usageCount ?? 0 }),
             action: 'get',
             prompt: toPromptOutput(p),
           }
@@ -949,7 +953,7 @@ export function promptsToolDefinition(config, promptStore, injectionStore, ctx) 
           })
           return {
             ok: true,
-            message: `已创建提示词「${created.name}」（分类：${created.category}，id=${created.id}）——可 inject 注入当前会话，或 update <id> 继续修改`,
+            message: pt('promptmsg.created', { name: created.name, category: created.category, id: created.id }),
             action: 'create',
             prompt: toPromptOutput(created),
           }
@@ -958,33 +962,33 @@ export function promptsToolDefinition(config, promptStore, injectionStore, ctx) 
           // 按 id 修改：白名单字段（name/content/description/category/tags/enabled），
           // 传哪个改哪个；至少一个字段（避免空更新）。与 GUI 编辑同一校验。
           const id = String(args?.id ?? '').trim()
-          if (!id) return { ok: false, message: 'update 需要 id（来自 list 返回或 create 结果）', action: 'update' }
+          if (!id) return { ok: false, message: pt('promptmsg.updateNeedsId'), action: 'update' }
           const patch = {}
           for (const key of ['name', 'content', 'description', 'category', 'tags', 'enabled']) {
             if (args?.[key] !== undefined) patch[key] = args[key]
           }
           if (Object.keys(patch).length === 0) {
-            return { ok: false, message: 'update 至少要改一个字段（name/content/description/category/tags/enabled）', action: 'update' }
+            return { ok: false, message: pt('promptmsg.updateNoFields'), action: 'update' }
           }
           const updated = promptStore.update(id, patch)
           return {
             ok: true,
-            message: `已更新提示词「${updated.name}」（分类：${updated.category}，enabled=${updated.enabled !== false}）`,
+            message: pt('promptmsg.updated', { name: updated.name, category: updated.category, enabled: updated.enabled !== false }),
             action: 'update',
             prompt: toPromptOutput(updated),
           }
         }
         if (action === 'inject') {
           const id = String(args?.id ?? '').trim()
-          if (!id) return { ok: false, message: 'inject 需要 id（来自 list 返回）', action: 'inject' }
+          if (!id) return { ok: false, message: pt('promptmsg.injectNeedsId'), action: 'inject' }
           const p = promptStore.get(id)
-          if (!p) return { ok: false, message: `提示词不存在：${id}（可先 list 查看可用提示词）`, action: 'inject' }
+          if (!p) return { ok: false, message: pt('promptmsg.missingInject', { id }), action: 'inject' }
           // 禁用提示词不可注入（与 list 隐藏同一语义：用户停用的不用于 AI 注入）
           if (p.enabled === false) {
-            return { ok: false, message: `「${p.name}」已禁用，不能注入（可在 GUI 提示词库中重新启用）`, action: 'inject' }
+            return { ok: false, message: pt('promptmsg.cannotInjectDisabled', { name: p.name }), action: 'inject' }
           }
           if (injectionStore.hasSource(id)) {
-            return { ok: false, message: `「${p.name}」已在注入中（可先在 GUI「注入中」移除再重新注入）`, action: 'inject' }
+            return { ok: false, message: pt('promptmsg.alreadyInjecting', { name: p.name }), action: 'inject' }
           }
           // immediate=true = **立即注入**：当前回合/马上唤醒立即生效，
           // **只注入一次——忽略 rounds/every 两个数字**（用户拍板语义）：
@@ -1003,7 +1007,7 @@ export function promptsToolDefinition(config, promptStore, injectionStore, ctx) 
             const steered = sessionId ? steerImmediateInjection(ctx, sessionId, p.name) : false
             return {
               ok: true,
-              message: `已立即注入「${p.name}」：当前回合生效，仅此一次（不受次数/间隔影响）${steered ? '' : '（插话未送达——将在下一轮生效）'}`,
+              message: pt('promptmsg.injectNow', { name: p.name, tail: steered ? '' : pt('promptmsg.steerMissed') }),
               action: 'inject',
               injection,
             }
@@ -1011,12 +1015,12 @@ export function promptsToolDefinition(config, promptStore, injectionStore, ctx) 
           // rounds：缺省 1=只注入一次；0=无限；其余须 ≥1 整数（与 Web API 同规则）
           const rounds = args?.rounds === undefined ? 1 : Number(args.rounds)
           if (rounds !== 0 && (!Number.isInteger(rounds) || rounds < 1)) {
-            return { ok: false, message: 'rounds 必须是 ≥1 的整数，或 0 表示无限', action: 'inject' }
+            return { ok: false, message: pt('promptmsg.roundsInvalid'), action: 'inject' }
           }
           // every：缺省 1=每回合；0=只注入一次；其余须 ≥0 整数
           const every = args?.every === undefined ? 1 : Number(args.every)
           if (!Number.isInteger(every) || every < 0) {
-            return { ok: false, message: 'every 必须是 ≥0 的整数（0 = 只注入一次）', action: 'inject' }
+            return { ok: false, message: pt('promptmsg.everyInvalid'), action: 'inject' }
           }
           const injection = injectionStore.add({
             sourcePromptId: id,
@@ -1040,12 +1044,12 @@ export function promptsToolDefinition(config, promptStore, injectionStore, ctx) 
             : (rounds === 0 ? '，直到手动停止' : '，用尽自动结束')
           return {
             ok: true,
-            message: `已注入「${p.name}」：${times}${cadence}，模型下一轮生效${ending}`,
+            message: pt('promptmsg.injectScheduled', { name: p.name, times, cadence, ending }),
             action: 'inject',
             injection,
           }
         }
-        return { ok: false, message: `未知 action：${action}（支持 list / get / inject）`, action: action || '' }
+        return { ok: false, message: pt('promptmsg.unknownAction', { action }), action: action || '' }
       } catch (error) {
         return { ok: false, message: error?.message ?? String(error), action: action || '' }
       }

--- a/lib/review.js
+++ b/lib/review.js
@@ -29,6 +29,16 @@
  */
 
 import { todayStamp } from './store.js'
+import { translate, getLocale, REVIEW_DICT, REVIEW_CMD_DICT, MISC_DICT } from './i18n.js'
+
+/** Translate through the REVIEW_DICT dictionary in the active locale. */
+const rt = (key, params) => translate(REVIEW_DICT, key, params)
+const _t = (dict, key, params) => {
+  const hit = translate(dict, key, params, getLocale())
+  return hit === key ? undefined : hit
+}
+/** Translate through REVIEW_CMD_DICT (falling back to MISC_DICT) in the active host locale. */
+const rct = (key, params) => _t(REVIEW_CMD_DICT, key, params) ?? translate(MISC_DICT, key, params, getLocale())
 
 /**
  * Install the per-session review turn counter.
@@ -88,14 +98,14 @@ export function reviewTurnCounter(ctx, getRuntime) {
 export function reviewStatusTool(getRuntime, counter) {
   return {
     name: 'memory_review_status',
-    description: '完成每 N 个用户回合的自动记忆审查。**无需每轮调用**：到期提醒由程序在快照中动态注入（出现「记忆审查已到期」提醒时才需要执行审查）；complete：审查全部执行完毕后调用，复位计数（漏做则下一轮继续提醒）；check：仅在你需要手动确认当前进度时调用（返回 due 与距上次审查的回合数）。',
+    get description() { return rt('reviewStatus.desc') },
     parameters: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
           enum: ['check', 'complete'],
-          description: 'check=查询审查是否到期；complete=完成审查后复位计数',
+          get description() { return rt('reviewStatus.action') },
         },
       },
       required: ['action'],
@@ -122,17 +132,17 @@ export function reviewStatusTool(getRuntime, counter) {
         const runtime = getRuntime()
         const turns = counter.turnsOf(exec?.agent)
         if (turns < runtime.reviewInterval) {
-          return { ok: true, message: `审查未到期（${turns}/${runtime.reviewInterval}），无需复位，计数保持不变。` }
+          return { ok: true, message: rt('reviewStatus.notDue', { turns, interval: runtime.reviewInterval }) }
         }
         counter.complete(exec?.agent)
-        return { ok: true, message: '审查计数已复位（下次到期按新间隔重新计数）。' }
+        return { ok: true, message: rt('reviewStatus.reset') }
       }
       const runtime = getRuntime()
       const turns = counter.turnsOf(exec?.agent)
       const due = turns >= runtime.reviewInterval
       const message = due
-        ? `记忆审查已到期（距上次审查 ${turns} 个回合，间隔 ${runtime.reviewInterval}）：执行审查，完成后必须调用 complete 复位。`
-        : `记忆审查未到期（距上次审查 ${turns}/${runtime.reviewInterval} 个回合），本轮无需审查（也不要调用 complete）。`
+        ? rt('reviewStatus.due', { turns, interval: runtime.reviewInterval })
+        : rt('reviewStatus.notDueYet', { turns, interval: runtime.reviewInterval })
       return {
         ok: true,
         message,
@@ -159,22 +169,22 @@ export function reviewStatusTool(getRuntime, counter) {
 export function suggestToolDefinition(config, queue) {
   return {
     name: config.suggestToolName,
-    description: '提出一条长期记忆建议（记忆审查使用）。不会直接修改记忆，只会加入待用户确认的队列；重复内容会累计建议次数。',
+    get description() { return rt('suggest.desc') },
     parameters: {
       type: 'object',
       properties: {
         target: {
           type: 'string',
           enum: ['memory', 'user', 'todo-life', 'todo-work', 'todo-project', 'todo-daily'],
-          description: '轨：memory=环境/项目事实，user=用户事实；todo-life/todo-work/todo-project/todo-daily=待办建议（确认后写入对应待办轨）',
+          get description() { return rt('suggest.target') },
         },
         content: {
           type: 'string',
-          description: '建议记忆的条目内容（可多行）',
+          get description() { return rt('suggest.content') },
         },
         reason: {
           type: 'string',
-          description: '为什么值得记住（引用会话中的证据）',
+          get description() { return rt('suggest.reason') },
         },
       },
       required: ['target', 'content', 'reason'],
@@ -198,10 +208,10 @@ export function suggestToolDefinition(config, queue) {
       const reason = String(args.reason ?? '').trim()
       const validTargets = ['memory', 'user', 'todo-life', 'todo-work', 'todo-project', 'todo-daily']
       if (!validTargets.includes(target)) {
-        return { ok: false, message: `无效 target "${target}"（应为 ${validTargets.join('/')}）` }
+        return { ok: false, message: rt('suggest.invalidTarget', { target, valid: validTargets.join('/') }) }
       }
-      if (!content) return { ok: false, message: 'content 不能为空' }
-      if (!reason) return { ok: false, message: 'reason 不能为空（必须引用会话中的证据）' }
+      if (!content) return { ok: false, message: rt('suggest.emptyContent') }
+      if (!reason) return { ok: false, message: rt('suggest.emptyReason') }
       return enqueueSuggestion(queue, target, content, reason, exec?.agent)
     },
   }
@@ -238,7 +248,7 @@ export function enqueueSuggestion(queue, target, content, reason, agent) {
       if (reason) existing.reason = reason
       return {
         ok: true,
-        message: `该内容此前已建议（累计第 ${existing.hits} 次），已更新证据，等待用户确认`,
+        message: rct('reviewcmd.dedup', { hits: existing.hits }),
         queued: entries.length,
       }
     }
@@ -312,11 +322,11 @@ export function approveSuggestions(store, todoStore, queue, indices, agent, edit
         }
       }
       if (outcome.ok) {
-        lines.push(`✓ #${number} [${target}] 已写入${isTodo ? '待办' : '记忆'}`)
+        lines.push(rct(isTodo ? 'reviewcmd.writtenTodo' : 'reviewcmd.writtenMemory', { n: number, target }))
       } else if (outcome.message.includes('已存在')) {
-        lines.push(`- #${number} [${target}] 已存在，跳过`)
+        lines.push(rct('reviewcmd.existsSkip', { n: number, target }))
       } else {
-        lines.push(`✗ #${number} [${target}] ${outcome.message}`)
+        lines.push(rct('reviewcmd.failed', { n: number, target, detail: outcome.message }))
         kept.push(entry)
       }
     })
@@ -402,9 +412,9 @@ export function archiveSuggestions(archive, queue, indices) {
 export function promoteArchived(store, todoStore, archive, target, match, cwd) {
   const entries = archive.entriesOf(target, cwd)
   const hits = entries.filter((entry) => entry.includes(match))
-  if (hits.length === 0) return { ok: false, message: `归档中没有条目包含片段 "${match}"` }
+  if (hits.length === 0) return { ok: false, message: rct('misc.archiveNoMatch', { match }) }
   if (hits.length > 1) {
-    return { ok: false, message: `片段 "${match}" 匹配到 ${hits.length} 个归档条目，请用更精确的片段` }
+    return { ok: false, message: rct('misc.archiveMultiMatch', { match, count: hits.length }) }
   }
   const raw = hits[0]
   // todo 归档条目带（原轨：todo-*）标记，转正写回对应待办轨
@@ -416,14 +426,14 @@ export function promoteArchived(store, todoStore, archive, target, match, cwd) {
     .replace(/\n（归档理由：[\s\S]*?）\s*$/, '')
     .replace(/\n（原轨：[^\n]*）\s*$/, '')
     .trim()
-  if (!content) return { ok: false, message: '归档条目内容为空，无法转正' }
+  if (!content) return { ok: false, message: rct('misc.promoteEmpty') }
   const writeAgent = cwd ? { session: { header: { cwd } } } : undefined
   const outcome = writeTarget.startsWith('todo-')
     ? todoStore.addTodo(writeTarget.slice(5), content, {}, cwd)
     : store.add(writeTarget, content, writeAgent)
   if (!outcome.ok) return outcome
   archive.remove(target, match, cwd)
-  return { ok: true, message: `已转正写入 ${writeTarget}（${content.length} 字符），归档条目已移除` }
+  return { ok: true, message: rct('misc.promoted', { target: writeTarget, chars: content.length }) }
 }
 
 /**
@@ -435,7 +445,7 @@ export function promoteArchived(store, todoStore, archive, target, match, cwd) {
  * @returns {object} a CommandDefinition-shaped object for ctx.commands.register.
  */
 export function reviewCommand(config, store, todoStore, archive, queue) {
-  const formatEntry = (entry, index) => `${index + 1}. [${entry.target}] ${entry.content}（理由：${entry.reason ?? '无'}）`
+  const formatEntry = (entry, index) => rct('reviewcmd.entryLine', { i: index + 1, target: entry.target, content: entry.content, reason: entry.reason ?? rct('reviewcmd.noReason') })
 
   return {
     name: config.commandName,
@@ -453,32 +463,32 @@ export function reviewCommand(config, store, todoStore, archive, queue) {
       switch (op) {
         case 'list': {
           const entries = queue.read()
-          if (entries.length === 0) return { kind: 'success', text: '没有待确认的记忆建议。' }
+          if (entries.length === 0) return { kind: 'success', text: rct('reviewcmd.emptyQueue') }
           const lines = entries.map(formatEntry)
-          return { kind: 'success', text: `待确认的记忆建议（${entries.length} 条）：\n${lines.join('\n')}` }
+          return { kind: 'success', text: rct('reviewcmd.listHead', { count: entries.length }) + '\n' + lines.join('\n') }
         }
         case 'approve': {
-          if (!validIndices) return { kind: 'error', text: '用法：approve <序号>…（序号来自 list）' }
+          if (!validIndices) return { kind: 'error', text: rct('reviewcmd.usageApprove') }
           const report = approveSuggestions(store, todoStore, queue, indices, invocation.agent)
           return {
             kind: 'success',
-            text: `${report.lines.join('\n')}\n剩余待确认：${report.remaining} 条`,
+            text: `${report.lines.join('\n')}\n${rct('reviewcmd.remaining', { count: report.remaining })}`,
           }
         }
         case 'archive': {
-          if (!validIndices) return { kind: 'error', text: '用法：archive <序号>…（序号来自 list）' }
+          if (!validIndices) return { kind: 'error', text: rct('reviewcmd.usageArchive') }
           const report = archiveSuggestions(archive, queue, indices)
           return {
             kind: 'success',
-            text: `${report.lines.join('\n')}\n剩余待确认：${report.remaining} 条`,
+            text: `${report.lines.join('\n')}\n${rct('reviewcmd.remaining', { count: report.remaining })}`,
           }
         }
         case 'reject': {
-          if (!validIndices) return { kind: 'error', text: '用法：reject <序号>…（序号来自 list）' }
+          if (!validIndices) return { kind: 'error', text: rct('reviewcmd.usageReject') }
           const report = rejectSuggestions(queue, indices)
           return {
             kind: 'success',
-            text: `已拒绝 ${report.removed} 条建议。剩余待确认：${report.remaining} 条`,
+            text: rct('reviewcmd.rejectedSome', { count: report.removed, remaining: report.remaining }),
           }
         }
         case 'approve-all': {
@@ -486,15 +496,15 @@ export function reviewCommand(config, store, todoStore, archive, queue) {
           const report = approveSuggestions(store, todoStore, queue, all, invocation.agent)
           return {
             kind: 'success',
-            text: `${report.lines.join('\n')}\n剩余待确认：${report.remaining} 条`,
+            text: `${report.lines.join('\n')}\n${rct('reviewcmd.remaining', { count: report.remaining })}`,
           }
         }
         case 'reject-all': {
           const report = rejectSuggestions(queue, Array.from({ length: queue.read().length }, (_, i) => i + 1))
-          return { kind: 'success', text: `已拒绝全部 ${report.removed} 条建议。` }
+          return { kind: 'success', text: rct('reviewcmd.rejectedAll', { count: report.removed }) }
         }
         default:
-          return { kind: 'error', text: `未知操作 "${op}"（支持：list / approve / archive / reject / approve-all / reject-all）` }
+          return { kind: 'error', text: rct('misc.unknownOp', { op }) }
       }
     },
   }

--- a/lib/review.js
+++ b/lib/review.js
@@ -321,10 +321,14 @@ export function approveSuggestions(store, todoStore, queue, indices, agent, edit
           outcome = { ok: false, message: error instanceof Error ? error.message : String(error) }
         }
       }
-      if (outcome.ok) {
-        lines.push(rct(isTodo ? 'reviewcmd.writtenTodo' : 'reviewcmd.writtenMemory', { n: number, target }))
-      } else if (outcome.message.includes('已存在')) {
+      if (outcome.duplicate === true || (!outcome.ok && (outcome.message.includes('已存在') || outcome.message.includes('already exists')))) {
+        // Duplicate detection is locale-neutral: store.add returns
+        // ok:true + duplicate:true for a dup, so the duplicate check must
+        // come FIRST; the message-substring fallbacks cover older flows
+        // that only carry localized text.
         lines.push(rct('reviewcmd.existsSkip', { n: number, target }))
+      } else if (outcome.ok) {
+        lines.push(rct(isTodo ? 'reviewcmd.writtenTodo' : 'reviewcmd.writtenMemory', { n: number, target }))
       } else {
         lines.push(rct('reviewcmd.failed', { n: number, target, detail: outcome.message }))
         kept.push(entry)

--- a/lib/search-docs.js
+++ b/lib/search-docs.js
@@ -32,6 +32,10 @@ import {
 import { readdir, rename, stat, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, extname, join, resolve } from 'node:path'
+import { translate, getLocale, MISC2_DICT } from './i18n.js'
+
+/** Translate through MISC2_DICT in the active host locale. */
+const sdt = (key, params) => translate(MISC2_DICT, key, params, getLocale())
 
 // ---------------------------------------------------------------------------
 // Provider 注册表（可替换实现的核心）：名字 → 工厂函数 (config) => provider
@@ -1121,7 +1125,7 @@ export function searchDocsToolDefinition(config, search) {
       } catch {
         return {
           ok: false,
-          message: 'exts 参数格式不正确（应为扩展名数组或逗号分隔字符串）',
+          message: sdt('sd.badExts'),
           provider: '',
           type: kind,
           count: 0,
@@ -1169,7 +1173,7 @@ export function searchDocsToolDefinition(config, search) {
         if (contentEnabled && !effectiveContentQuery) {
           return {
             ok: false,
-            message: '内容检索需要关键词：请提供 contentQuery，或同时提供 query（content=true 时复用 query）',
+            message: sdt('sd.contentNeedsQuery'),
             provider: '',
             type: kind,
             count: 0,
@@ -1316,16 +1320,16 @@ export function searchDocsCommand(config, ctrl) {
       if (op === 'on') {
         ctrl.setEnabled(true)
         const status = ctrl.status()
-        return { kind: 'success', text: `已启用本地文档搜索工具（${status.toolName}）。provider 链：${status.providers.join(' → ')}` }
+        return { kind: 'success', text: sdt('sd.enabled', { tool: status.toolName, chain: status.providers.join(' → ') }) }
       }
       if (op === 'off') {
         ctrl.setEnabled(false)
-        return { kind: 'success', text: '已禁用本地文档搜索工具：工具已从模型可见列表中移除' }
+        return { kind: 'success', text: sdt('sd.disabled') }
       }
       const status = ctrl.status()
       return {
         kind: 'success',
-        text: `本地文档搜索工具：${status.enabled ? '已启用' : '已禁用（默认）'}\n工具名：${status.toolName}\nprovider 链：${status.providers.join(' → ')}\n默认扩展名：${status.defaultExts.join(', ')}\n用法：/memory_evolve_search_docs on|off`,
+        text: sdt('sd.status', { state: status.enabled ? sdt('sd.on') : sdt('sd.off'), tool: status.toolName, chain: status.providers.join(' → '), exts: status.defaultExts.join(', ') }),
       }
     },
   }

--- a/lib/session-orch.js
+++ b/lib/session-orch.js
@@ -23,6 +23,10 @@
  * 唤醒 = 替用户发消息，对方 GUI 可见全过程（可审计）。
  */
 import { randomUUID } from 'node:crypto'
+import { translate, getLocale, SESSION_DICT } from './i18n.js'
+
+/** Translate through SESSION_DICT in the active host locale. */
+const set_ = (key, params) => translate(SESSION_DICT, key, params, getLocale())
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -256,29 +260,29 @@ export class SessionOrch {
    */
   async rename({ sessionId, title, alias } = {}) {
     const sid = String(sessionId ?? '').trim()
-    if (sid === '') return { ok: false, message: 'rename 必填 sessionId（要改名的会话）' }
+    if (sid === '') return { ok: false, message: set_('ses.msg.renameNeedsSid') }
     const hasTitle = title !== undefined && String(title).trim() !== ''
     const hasAlias = alias !== undefined
     if (!hasTitle && !hasAlias) {
-      return { ok: false, message: 'rename 至少提供 title（会话名称）或 alias（会话别名）之一' }
+      return { ok: false, message: set_('ses.msg.renameNeedsOne') }
     }
     const parts = []
     // ① 会话名称（左侧列表标题）：需要 live 会话
     if (hasTitle) {
       const agent = this.agents.get(sid)
       if (agent === undefined) {
-        return { ok: false, message: `会话 ${sid} 不在当前进程，无法改名称（可先 wake 恢复再改，或用 list 确认 ID）` }
+        return { ok: false, message: set_('ses.msg.notLoadedRename', { sid }) }
       }
       try {
         this.sessionTitle.rename(agent.session, String(title).trim())
         parts.push(`会话名称已设为「${String(title).trim()}」`)
       } catch (error) {
-        return { ok: false, message: `改会话名称失败: ${errText(error)}` }
+        return { ok: false, message: set_('ses.msg.renameFailed', { detail: errText(error) }) }
       }
     }
     // ② 会话别名（aliases.json，广播/快照显示；alias 空串 = 清除）
     if (hasAlias) {
-      if (!this.aliasStore) return { ok: false, message: '别名存储不可用（aliases.json）' }
+      if (!this.aliasStore) return { ok: false, message: set_('ses.msg.aliasStoreMissing') }
       const result = this.aliasStore.set(sid, alias)
       if (!result.ok) return { ok: false, message: result.message }
       parts.push(result.message)
@@ -305,10 +309,10 @@ export class SessionOrch {
    *   spawned?:boolean, spawnedBy?:string|null, message?:string}}
    */
   me(requester) {
-    if (!requester) return { ok: false, message: '无法获取当前会话信息（调用上下文缺少 agent）' }
+    if (!requester) return { ok: false, message: set_('ses.msg.noRequester') }
     const agent = requester
     const sid = agent.id ?? agent.session?.id
-    if (!sid) return { ok: false, message: '无法获取当前会话 ID' }
+    if (!sid) return { ok: false, message: set_('ses.msg.noSelfId') }
     let title = null
     try {
       title = agent?.session ? (this.sessionTitle?.get?.(agent.session)?.title ?? null) : null
@@ -519,7 +523,7 @@ export class SessionOrch {
   async spawn({ prompt, cwd, roomId, model, provider, agentPreset, by, requester } = {}) {
     const text = String(prompt ?? '').trim()
     if (text === '') {
-      return { ok: false, message: 'spawn 必填 prompt（新会话的完整提示词，可长文本自由组合：角色/任务/要求一次写清）' }
+      return { ok: false, message: set_('ses.msg.spawnNeedsPrompt') }
     }
     // Agent 预设校验（2026-08-11 P3 任务）：id 格式 + roster 存在性。
     // 格式不合法 / 不存在都**不创建会话**（宁可报错也不留一个组装失败的
@@ -530,7 +534,7 @@ export class SessionOrch {
       if (!PRESET_ID_RE.test(presetRaw)) {
         return {
           ok: false,
-          message: `agentPreset 格式不合法："${presetRaw}"（须匹配 [a-z0-9][a-z0-9-]*，如 code/cordis/minimal/standard）`,
+          message: set_('ses.msg.badPreset', { preset: presetRaw }),
         }
       }
       const available = this.#listPresets()
@@ -681,7 +685,7 @@ export class SessionOrch {
         ...(seed ? { seed } : {}),
       })
     } catch (error) {
-      return { ok: false, message: `创建会话失败: ${errText(error)}` }
+      return { ok: false, message: set_('ses.msg.spawnFailed', { detail: errText(error) }) }
     }
     this.spawnedHandles.set(sessionId, handle)
     // 挂到工作区（左侧"项目"分组；GUI 新建会 attach，spawn 曾漏掉导致
@@ -721,7 +725,7 @@ export class SessionOrch {
     try {
       handle.agent.followup(userMessage(text))
     } catch (error) {
-      return { ok: false, message: `会话 ${sessionId} 已创建但派发初始任务失败: ${errText(error)}` }
+      return { ok: false, message: set_('ses.msg.dispatchFailed', { sid: sessionId, detail: errText(error) }) }
     }
     // 预设提示（与 provider/model 同款：message 里如实反映创建时用的配置；
     // 未显式传预设 = 走 DSH 默认（agent-presets.default 设置），不啰嗦）
@@ -732,7 +736,7 @@ export class SessionOrch {
       provider: resolvedProvider ?? null,
       agentPreset: resolvedPreset,
       attach,
-      message: `已创建会话 ${sessionId} 并开始执行任务${presetNote}${roomNote}${providerNote}${attachNote}`,
+      message: set_('ses.msg.spawned', { sid: sessionId, notes: `${presetNote}${roomNote}${providerNote}${attachNote}` }),
     }
   }
 
@@ -744,8 +748,8 @@ export class SessionOrch {
   async wake({ sessionId, prompt } = {}) {
     const sid = String(sessionId ?? '').trim()
     const text = String(prompt ?? '').trim()
-    if (sid === '') return { ok: false, message: 'wake 必填 sessionId（要唤醒的会话 ID）' }
-    if (text === '') return { ok: false, message: 'wake 必填 prompt（要对方做的事，如"现在开始执行：…"）' }
+    if (sid === '') return { ok: false, message: set_('ses.msg.wakeNeedsSid') }
+    if (text === '') return { ok: false, message: set_('ses.msg.wakeNeedsPrompt') }
     let agent = this.agents.get(sid)
     if (agent === undefined) {
       // 进程重启后 agent 不在内存：从持久化恢复（需 sessionPersistence 已配置）。
@@ -807,21 +811,21 @@ export class SessionOrch {
       } catch (error) {
         return {
           ok: false,
-          message: `会话 ${sid} 不在当前进程且自动恢复失败（可能不存在/是跨实例会话/持久化不可用）: ${errText(error)}`,
+          message: set_('ses.msg.wakeRestoreFailed', { sid, detail: errText(error) }),
         }
       }
     }
     try {
       agent.followup(userMessage(text))
     } catch (error) {
-      return { ok: false, message: `唤醒会话 ${sid} 失败: ${errText(error)}` }
+      return { ok: false, message: set_('ses.msg.wakeFailed', { sid, detail: errText(error) }) }
     }
     // ⚠️ 文案诚实原则（2026-08-11 用户拍板）：followup 只保证**送达**，
     // 不保证**成功**——对方不在本进程（离线恢复失败）或模型配置缺失时
     // 回合会失败（如 {{model}} 无值）。不能说"已唤醒/它正在处理"，
     // 那会让产品经理误以为对方在干活、一直等。必须提示：等几秒后
     // status 确认对方真的 running。
-    return { ok: true, sessionId: sid, message: `指令已送达会话 ${sid}（已入队）。⚠️ 送达≠成功：对方实际能否跑起来需**稍后确认**——离线恢复或模型配置缺失时回合可能失败。等几秒后 de_session status 查它是否 running；忙完前不要重复派活` }
+    return { ok: true, sessionId: sid, message: set_('ses.msg.wakeQueued', { sid }) }
   }
 
   /**
@@ -832,7 +836,7 @@ export class SessionOrch {
    */
   status(sessionId) {
     const sid = String(sessionId ?? '').trim()
-    if (sid === '') return { ok: false, message: 'status 必填 sessionId' }
+    if (sid === '') return { ok: false, message: set_('ses.msg.statusNeedsSid') }
     const now = Date.now()
     const agent = this.agents.get(sid)
     if (agent === undefined) {
@@ -849,7 +853,7 @@ export class SessionOrch {
         // （offline 也可查）；名称需 live session（sessionTitle），offline=null
         title: null,
         alias: this.aliasStore?.get(sid) ?? null,
-        message: '会话不在当前进程（离线或不存在；同实例会话重启后会自动恢复）',
+        message: set_('ses.msg.statusOffline'),
       }
     }
     // status 的 live 分支曾**没有 message 字段** → render 只处理 message/
@@ -869,7 +873,7 @@ export class SessionOrch {
       now,
       title,
       alias: this.aliasStore?.get(sid) ?? null,
-      message: `会话 ${sid} 状态：${agent.status}（${agent.status === 'running' ? '正在生成' : '空闲，等指令'}）`,
+      message: set_('ses.msg.statusLine', { sid, status: agent.status, detail: agent.status === 'running' ? set_('ses.msg.statusRunning') : set_('ses.msg.statusIdle') }),
     }
   }
 
@@ -935,7 +939,7 @@ export class SessionOrch {
    */
   find({ query, limit } = {}) {
     const q = String(query ?? '').trim()
-    if (q === '') return { ok: false, message: 'find 必填 query（要查找的名称/别名/ID 关键字）' }
+    if (q === '') return { ok: false, message: set_('ses.msg.findNeedsQuery') }
     // 上限防御（默认 20，最大 50）
     const limitN = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 50) : 20
     const ql = q.toLowerCase()
@@ -1016,7 +1020,7 @@ export class SessionOrch {
   #joinRoom(sessionId, roomId) {
     try {
       const broadcast = this.getBroadcastStore?.()
-      if (!broadcast) return { ok: false, message: '广播模块未启用（可在运行时配置打开「会话广播」）' }
+      if (!broadcast) return { ok: false, message: set_('ses.msg.broadcastDisabled') }
       const result = broadcast.rooms.join(roomId, sessionId)
       if (!result?.ok) return { ok: false, message: result?.message ?? '加入房间失败' }
       return { ok: true }
@@ -1243,7 +1247,7 @@ export function sessionToolDefinition(orch) {
       },
     },
     async execute(args, ctx) {
-      if (!orch) return { ok: false, message: '会话编排未就绪（DSH agents 服务不可用）' }
+      if (!orch) return { ok: false, message: set_('ses.msg.orchNotReady') }
       const by = ctx?.agent?.session?.id ?? ''
       const action = args.action
       try {
@@ -1270,10 +1274,10 @@ export function sessionToolDefinition(orch) {
             // 当前会话自身信息（"我是谁"：ID/名称/别名/cwd/模型/状态）
             return orch.me(ctx?.agent)
           default:
-            return { ok: false, message: `未知 action "${action}"` }
+            return { ok: false, message: set_('ses.msg.unknownAction', { action }) }
         }
       } catch (error) {
-        return { ok: false, message: `de_session ${action} 失败: ${errText(error)}` }
+        return { ok: false, message: set_('ses.msg.actionFailed', { action, detail: errText(error) }) }
       }
     },
   }

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -342,7 +342,7 @@ export function skillManageTool(ctx, config) {
       render: (_args, value) => {
         const lines = [value.message ?? '']
         if (Array.isArray(value.entries) && value.entries.length > 0) {
-          lines.push(`已有技能（${value.entries.length} 个）：`)
+          lines.push(skt('skill.listHeader', { count: value.entries.length }))
           value.entries.forEach((entry, index) => lines.push(`${index + 1}. ${entry.name} — ${entry.description}`))
         }
         return [{ type: 'text', text: lines.join('\n') }]

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -26,6 +26,10 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { translate, SKILL_DICT } from './i18n.js'
+
+/** Translate through the SKILL_DICT dictionary in the active locale. */
+const skt = (key, params) => translate(SKILL_DICT, key, params)
 import { join } from 'node:path'
 
 /** Skill name grammar (matches DSH's isSkillName; kebab-case rules out traversal). */
@@ -250,7 +254,7 @@ export function skillManageTool(ctx, config) {
       const list = await skills.list({})
       const skill = list.find((entry) => entry.name === name)
       return skill?.invocation?.modelInvocable === false
-        ? `技能 "${name}" 已被禁用（modelInvocable: false），不执行写入`
+        ? skt('skill.disabledShadow', { name })
         : undefined
     } catch {
       return undefined
@@ -260,52 +264,52 @@ export function skillManageTool(ctx, config) {
   /** Validate a create/patch body against the canonical format. */
   const validateBody = (name, description, body) => {
     if (!isSkillName(name)) {
-      return { ok: false, message: `无效技能名 "${name}"（必须 kebab-case 小写，如 systematic-debugging）` }
+      return { ok: false, message: skt('skill.invalidName', { name }) }
     }
     if (description !== undefined && !String(description).trim()) {
-      return { ok: false, message: 'description 不能为空' }
+      return { ok: false, message: skt('skill.emptyDescription') }
     }
     if (typeof body !== 'string' || body.length === 0) {
-      return { ok: false, message: 'body 不能为空（完整 SKILL.md 内容，含 frontmatter）' }
+      return { ok: false, message: skt('skill.emptyBody') }
     }
     if (body.length > config.skillMaxBytes) {
-      return { ok: false, message: `SKILL.md 超过大小上限 ${config.skillMaxBytes} 字节` }
+      return { ok: false, message: skt('skill.tooLarge', { limit: config.skillMaxBytes }) }
     }
     const parsed = parseFrontmatter(body)
     if (!parsed) {
-      return { ok: false, message: 'body 不是规范 SKILL.md：必须以 --- 开头的 frontmatter（含单行 name 与 description），后接正文。注意 description 请用双引号包裹（如 description: "..."），未加引号且含冒号+空格的值会被 YAML 拒绝' }
+      return { ok: false, message: skt('skill.badFrontmatter') }
     }
     if (parsed.name !== name) {
-      return { ok: false, message: `frontmatter 的 name（${parsed.name}）必须与技能名一致（${name}）` }
+      return { ok: false, message: skt('skill.nameMismatch', { parsed: parsed.name, name }) }
     }
     if (description !== undefined && parsed.description !== String(description).trim()) {
-      return { ok: false, message: 'frontmatter 的 description 与传入的 description 不一致' }
+      return { ok: false, message: skt('skill.descriptionMismatch') }
     }
     return { ok: true }
   }
 
   return {
     name: config.skillManageToolName,
-    description: '管理技能库（默认目录 ~/.agents/skills，DSH 技能库）：create 创建新技能（body 为完整 SKILL.md，含 --- frontmatter：name 与 description 单行必填）；patch 更新已有技能（必须先用 read 读取过，body 为完整修订版）；read 读取技能全文；list 列出已有技能。技能命名必须 kebab-case 类级名称（如 systematic-debugging），禁止一次性任务名。',
+    get description() { return skt('skill.desc') },
     parameters: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
           enum: ['create', 'patch', 'read', 'list'],
-          description: '要执行的操作',
+          get description() { return skt('skill.action') },
         },
         name: {
           type: 'string',
-          description: '技能名（kebab-case 小写）',
+          get description() { return skt('skill.name') },
         },
         description: {
           type: 'string',
-          description: 'create 时的一句话描述（说明何时使用该技能，将写入 frontmatter）',
+          get description() { return skt('skill.description') },
         },
         body: {
           type: 'string',
-          description: 'create/patch 时的完整 SKILL.md 内容（--- frontmatter + 正文：概览/步骤/命令/坑/验证）',
+          get description() { return skt('skill.body') },
         },
       },
       required: ['action'],

--- a/lib/skills.js
+++ b/lib/skills.js
@@ -26,10 +26,12 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
-import { translate, SKILL_DICT } from './i18n.js'
+import { translate, getLocale, SKILL_DICT, SKILL_MSG_DICT } from './i18n.js'
 
 /** Translate through the SKILL_DICT dictionary in the active locale. */
 const skt = (key, params) => translate(SKILL_DICT, key, params)
+/** Translate through SKILL_MSG_DICT in the active host locale. */
+const smt = (key, params) => translate(SKILL_MSG_DICT, key, params, getLocale())
 import { join } from 'node:path'
 
 /** Skill name grammar (matches DSH's isSkillName; kebab-case rules out traversal). */
@@ -154,14 +156,14 @@ export function listPendingSkills(dir) {
  *   outcome; refuses to overwrite a live skill with the same name.
  */
 export function approvePendingSkill(pendingDir, skillDir, name) {
-  if (!isSkillName(name)) return { ok: false, message: `无效技能名 "${name}"` }
+  if (!isSkillName(name)) return { ok: false, message: smt('skillmsg.invalidNameShort', { name }) }
   const from = join(pendingDir, name)
   if (!existsSync(join(from, 'SKILL.md'))) {
-    return { ok: false, message: `待确认技能 "${name}" 不存在` }
+    return { ok: false, message: smt('skillmsg.pendingMissing', { name }) }
   }
   const to = join(skillDir, name)
   if (existsSync(join(to, 'SKILL.md'))) {
-    return { ok: false, message: `技能 "${name}" 已存在于技能库，请先处理再采纳` }
+    return { ok: false, message: smt('skillmsg.alreadyInLib', { name }) }
   }
   mkdirSync(skillDir, { recursive: true })
   renameSync(from, to)
@@ -175,10 +177,10 @@ export function approvePendingSkill(pendingDir, skillDir, name) {
  * @returns {{ok: true} | {ok: false, message: string}} the outcome.
  */
 export function rejectPendingSkill(pendingDir, name) {
-  if (!isSkillName(name)) return { ok: false, message: `无效技能名 "${name}"` }
+  if (!isSkillName(name)) return { ok: false, message: smt('skillmsg.invalidNameShort', { name }) }
   const target = join(pendingDir, name)
   if (!existsSync(join(target, 'SKILL.md'))) {
-    return { ok: false, message: `待确认技能 "${name}" 不存在` }
+    return { ok: false, message: smt('skillmsg.pendingMissing', { name }) }
   }
   rmSync(target, { recursive: true, force: true })
   return { ok: true }
@@ -352,17 +354,17 @@ export function skillManageTool(ctx, config) {
       switch (action) {
         case 'list': {
           const entries = listSkills(dir)
-          return { ok: true, message: `技能库（${entries.length} 个）：`, entries }
+          return { ok: true, message: smt('skillmsg.listHead', { count: entries.length }), entries }
         }
         case 'read': {
           if (!isSkillName(name)) {
-            return { ok: false, message: `无效技能名 "${name}"（必须 kebab-case 小写）` }
+            return { ok: false, message: smt('skillmsg.invalidNameCase', { name }) }
           }
           const content = readSkill(dir, name)
           if (content === undefined) {
-            return { ok: false, message: `技能 "${name}" 不存在` }
+            return { ok: false, message: smt('skillmsg.missing', { name }) }
           }
-          return { ok: true, message: `已读取技能 "${name}"（${content.length} 字节）`, name, content }
+          return { ok: true, message: smt('skillmsg.read', { name, bytes: content.length }), name, content }
         }
         case 'create': {
           const checked = validateBody(name, args.description, args.body)
@@ -370,7 +372,7 @@ export function skillManageTool(ctx, config) {
           const disabled = await disabledReason(name)
           if (disabled) return { ok: false, message: disabled }
           if (readSkill(dir, name) !== undefined) {
-            return { ok: false, message: `技能 "${name}" 已存在，请改用 patch 更新` }
+            return { ok: false, message: smt('skillmsg.existsUsePatch', { name }) }
           }
           // Skill creations go through the pending queue unless the user
           // enabled direct auto-harvest: the skill lands in
@@ -379,17 +381,17 @@ export function skillManageTool(ctx, config) {
           // Applies to every session (the review runs in the main session).
           if (!config.skillReviewEnabled) {
             if (readSkill(pendingDir, name) !== undefined) {
-              return { ok: false, message: `待确认队列已有技能 "${name}"，请勿重复创建（可在设置面板处理）` }
+              return { ok: false, message: smt('skillmsg.pendingDuplicate', { name }) }
             }
             writeSkill(pendingDir, name, args.body)
             return {
               ok: true,
-              message: `技能 "${name}" 已创建到待确认队列（等待用户在设置面板确认采纳，采纳后才会进入技能库）`,
+              message: smt('skillmsg.createdPending', { name }),
               name,
             }
           }
           writeSkill(dir, name, args.body)
-          return { ok: true, message: `技能 "${name}" 已创建（${args.body.length} 字节）`, name }
+          return { ok: true, message: smt('skillmsg.created', { name, bytes: args.body.length }), name }
         }
         case 'patch': {
           const checked = validateBody(name, undefined, args.body)
@@ -397,19 +399,19 @@ export function skillManageTool(ctx, config) {
           const disabled = await disabledReason(name)
           if (disabled) return { ok: false, message: disabled }
           if (readSkill(dir, name) === undefined) {
-            return { ok: false, message: `技能 "${name}" 不存在，请改用 create` }
+            return { ok: false, message: smt('skillmsg.missingUseCreate', { name }) }
           }
           if (!hasReadSkill(exec?.agent, config.skillManageToolName, name)) {
             return {
               ok: false,
-              message: `更新技能 "${name}" 前必须先读取它：请先调用 ${config.skillManageToolName} action=read name=${name}`,
+              message: smt('skillmsg.readFirst', { name, tool: config.skillManageToolName }),
             }
           }
           writeSkill(dir, name, args.body)
-          return { ok: true, message: `技能 "${name}" 已更新（${args.body.length} 字节）`, name }
+          return { ok: true, message: smt('skillmsg.updated', { name, bytes: args.body.length }), name }
         }
         default:
-          return { ok: false, message: `未知操作 "${action}"（支持 create / patch / read / list）` }
+          return { ok: false, message: smt('skillmsg.unknownAction', { action }) }
       }
     },
   }

--- a/lib/store.js
+++ b/lib/store.js
@@ -24,6 +24,12 @@
  */
 
 import { createHash } from 'node:crypto'
+import { getLocale, translate, STORE_DICT, STORE_TAIL_DICT } from './i18n.js'
+
+/** Translate through STORE_DICT in the active host locale. */
+const st = (key, params) => translate(STORE_DICT, key, params, getLocale())
+/** Translate through STORE_TAIL_DICT in the active host locale. */
+const stt = (key, params) => translate(STORE_TAIL_DICT, key, params, getLocale())
 import { spawnSync } from 'node:child_process'
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
@@ -808,7 +814,7 @@ export class MemoryStore {
   add(target, content, agent) {
     const loc = this.resolveTarget(target, agent)
     const text = String(content).trim()
-    if (!text) return { ok: false, message: '内容不能为空', target }
+    if (!text) return { ok: false, message: st('store.emptyContent'), target }
     if (this.injectionScan) {
       const threat = scanThreat(text)
       if (threat) return { ok: false, message: threat, target }
@@ -817,7 +823,7 @@ export class MemoryStore {
     return withLock(loc.dir, () => {
       const reload = this.reloadForAppend(target, agent)
       if (reload.kind === 'read-failed') {
-        return { ok: false, message: '记忆文件存在但无法读取，拒绝写入（防止清空已有记忆）', target }
+        return { ok: false, message: st('store.fileUnreadableWrite'), target }
       }
       const entries = reload.entries
       // entryIdMode=on（启用了 Git 同步的项目）：新条目前置随机身份证
@@ -837,14 +843,14 @@ export class MemoryStore {
         : entries.includes(stamped)
       if (dup) {
         return {
-          ok: true, message: '条目已存在，未重复添加', target,
+          ok: true, message: st('store.duplicate'), target,
           entries: [...entries], chars: this.charsOf(target, agent),
         }
       }
       const next = [...entries, withId]
       this.write(target, next, agent)
       return {
-        ok: true, message: `已添加（${target}：${entries.length} → ${next.length} 条）`, target,
+        ok: true, message: st('store.added', { target, before: entries.length, after: next.length }), target,
         entries: [...next], chars: next.join(ENTRY_DELIMITER).length,
       }
     })
@@ -862,8 +868,8 @@ export class MemoryStore {
     const loc = this.resolveTarget(target, agent)
     const oldText = String(match ?? '').trim()
     const newContent = String(content ?? '').trim()
-    if (!oldText) return { ok: false, message: 'match 不能为空', target }
-    if (!newContent) return { ok: false, message: 'content 不能为空（删除条目请用 remove）', target }
+    if (!oldText) return { ok: false, message: st('store.emptyMatch'), target }
+    if (!newContent) return { ok: false, message: st('store.emptyNewContent'), target }
     if (this.injectionScan) {
       const threat = scanThreat(newContent)
       if (threat) return { ok: false, message: threat, target }
@@ -873,22 +879,22 @@ export class MemoryStore {
       if (reload.kind === 'drift') {
         return {
           ok: false,
-          message: `拒绝写入：${loc.file} 的内容无法通过记忆工具解析往返（可能被手工编辑或外部进程修改）。已备份到 ${reload.backup}。请先将该文件整理为规范的 § 分隔条目，再重试。`,
+          message: st('store.driftGuardWrite', { file: loc.file, backup: reload.backup }),
           target, backup: reload.backup,
         }
       }
       if (reload.kind === 'read-failed') {
-        return { ok: false, message: '记忆文件存在但无法读取，拒绝写入（防止清空已有记忆）', target }
+        return { ok: false, message: st('store.fileUnreadableWrite'), target }
       }
       const entries = reload.entries
       const matches = entries.filter((entry) => entry.includes(oldText))
       if (matches.length === 0) {
-        return { ok: false, message: `没有条目包含片段 "${oldText}"`, target, entries: [...entries] }
+        return { ok: false, message: st('store.noMatch', { match: oldText }), target, entries: [...entries] }
       }
       if (matches.length > 1) {
         return {
           ok: false,
-          message: `片段 "${oldText}" 匹配到 ${matches.length} 个条目，请用更精确的片段`,
+          message: st('store.multiMatch', { match: oldText, count: matches.length }),
           target, matches: [...matches], entries: [...entries],
         }
       }
@@ -915,7 +921,7 @@ export class MemoryStore {
       next[index] = replacement
       this.write(target, next, agent)
       return {
-        ok: true, message: `已替换条目（${target}：${entries.length} 条不变）`, target,
+        ok: true, message: st('store.replaced', { target, count: entries.length }), target,
         entries: [...next], chars: next.join(ENTRY_DELIMITER).length,
       }
     })
@@ -931,28 +937,28 @@ export class MemoryStore {
   remove(target, match, agent) {
     const loc = this.resolveTarget(target, agent)
     const oldText = String(match ?? '').trim()
-    if (!oldText) return { ok: false, message: 'match 不能为空', target }
+    if (!oldText) return { ok: false, message: st('store.emptyMatch'), target }
     return withLock(loc.dir, () => {
       const reload = this.reload(target, agent)
       if (reload.kind === 'drift') {
         return {
           ok: false,
-          message: `拒绝写入：${loc.file} 的内容无法通过记忆工具解析往返。已备份到 ${reload.backup}。请先整理文件再重试。`,
+          message: st('store.driftGuardOp', { file: loc.file, backup: reload.backup }),
           target, backup: reload.backup,
         }
       }
       if (reload.kind === 'read-failed') {
-        return { ok: false, message: '记忆文件存在但无法读取，拒绝写入（防止清空已有记忆）', target }
+        return { ok: false, message: st('store.fileUnreadableWrite'), target }
       }
       const entries = reload.entries
       const matches = entries.filter((entry) => entry.includes(oldText))
       if (matches.length === 0) {
-        return { ok: false, message: `没有条目包含片段 "${oldText}"`, target, entries: [...entries] }
+        return { ok: false, message: st('store.noMatch', { match: oldText }), target, entries: [...entries] }
       }
       if (matches.length > 1) {
         return {
           ok: false,
-          message: `片段 "${oldText}" 匹配到 ${matches.length} 个条目，请用更精确的片段`,
+          message: st('store.multiMatch', { match: oldText, count: matches.length }),
           target, matches: [...matches], entries: [...entries],
         }
       }
@@ -961,7 +967,7 @@ export class MemoryStore {
       next.splice(index, 1)
       this.write(target, next, agent)
       return {
-        ok: true, message: `已删除条目（${target}：${entries.length} → ${next.length} 条）`, target,
+        ok: true, message: st('store.removed', { target, before: entries.length, after: next.length }), target,
         // removed：被删的整条原文（含时间戳）——供归档等"移动"场景直接
         // 追加到归档文件，避免二次匹配
         removed: matches[0],
@@ -983,27 +989,27 @@ export class MemoryStore {
   peek(target, match, agent) {
     const loc = this.resolveTarget(target, agent)
     const oldText = String(match ?? '').trim()
-    if (!oldText) return { ok: false, message: 'match 不能为空', target }
+    if (!oldText) return { ok: false, message: st('store.emptyMatch'), target }
     return withLock(loc.dir, () => {
       const reload = this.reload(target, agent)
       if (reload.kind === 'drift') {
         return {
           ok: false,
-          message: `拒绝操作：${loc.file} 的内容无法通过记忆工具解析往返。已备份到 ${reload.backup}。请先整理文件再重试。`,
+          message: st('store.driftGuardOp', { file: loc.file, backup: reload.backup }),
           target, backup: reload.backup,
         }
       }
       if (reload.kind === 'read-failed') {
-        return { ok: false, message: '记忆文件存在但无法读取，拒绝操作（防止误判条目）', target }
+        return { ok: false, message: st('store.fileUnreadableOp'), target }
       }
       const matches = reload.entries.filter((entry) => entry.includes(oldText))
       if (matches.length === 0) {
-        return { ok: false, message: `没有条目包含片段 "${oldText}"`, target }
+        return { ok: false, message: st('store.noMatch', { match: oldText }), target }
       }
       if (matches.length > 1) {
         return {
           ok: false,
-          message: `片段 "${oldText}" 匹配到 ${matches.length} 个条目，请用更精确的片段`,
+          message: st('store.multiMatch', { match: oldText, count: matches.length }),
           target,
         }
       }
@@ -1024,21 +1030,21 @@ export class MemoryStore {
   peekExact(target, entry, agent) {
     const loc = this.resolveTarget(target, agent)
     const exact = String(entry ?? '').trim()
-    if (!exact) return { ok: false, message: '条目不能为空', target }
+    if (!exact) return { ok: false, message: st('store.emptyEntry'), target }
     return withLock(loc.dir, () => {
       const reload = this.reload(target, agent)
       if (reload.kind === 'drift') {
         return {
           ok: false,
-          message: `拒绝操作：${loc.file} 的内容无法通过记忆工具解析往返。已备份到 ${reload.backup}。请先整理文件再重试。`,
+          message: st('store.driftGuardOp', { file: loc.file, backup: reload.backup }),
           target, backup: reload.backup,
         }
       }
       if (reload.kind === 'read-failed') {
-        return { ok: false, message: '记忆文件存在但无法读取，拒绝操作（防止误判条目）', target }
+        return { ok: false, message: st('store.fileUnreadableOp'), target }
       }
       if (!reload.entries.includes(exact)) {
-        return { ok: false, message: `主轨不存在该条目（可能已被删除）——未写入归档`, target }
+        return { ok: false, message: stt('storetail.mainMissing'), target }
       }
       return { ok: true, entry: exact, target }
     })
@@ -1060,18 +1066,18 @@ export class MemoryStore {
   removeExact(target, entry, agent) {
     const loc = this.resolveTarget(target, agent)
     const exact = String(entry ?? '').trim()
-    if (!exact) return { ok: false, message: '条目不能为空', target }
+    if (!exact) return { ok: false, message: st('store.emptyEntry'), target }
     return withLock(loc.dir, () => {
       const reload = this.reload(target, agent)
       if (reload.kind === 'drift') {
         return {
           ok: false,
-          message: `拒绝写入：${loc.file} 的内容无法通过记忆工具解析往返。已备份到 ${reload.backup}。请先整理文件再重试。`,
+          message: st('store.driftGuardOp', { file: loc.file, backup: reload.backup }),
           target, backup: reload.backup,
         }
       }
       if (reload.kind === 'read-failed') {
-        return { ok: false, message: '记忆文件存在但无法读取，拒绝写入（防止清空已有记忆）', target }
+        return { ok: false, message: st('store.fileUnreadableWrite'), target }
       }
       const entries = reload.entries
       // 精确匹配对身份证免疫（审查 P0）：展示层剥离 [id:…] 后回传的文本
@@ -1080,7 +1086,7 @@ export class MemoryStore {
       if (index === -1) {
         return {
           ok: false,
-          message: '条目不存在（可能已被删除，或文件被外部修改）——请刷新列表后重试',
+          message: stt('storetail.entryMissing'),
           target, entries: [...entries],
         }
       }
@@ -1088,7 +1094,7 @@ export class MemoryStore {
       next.splice(index, 1)
       this.write(target, next, agent)
       return {
-        ok: true, message: `已删除条目（${target}：${entries.length} → ${next.length} 条）`, target,
+        ok: true, message: st('store.removed', { target, before: entries.length, after: next.length }), target,
         entries: [...next], chars: next.join(ENTRY_DELIMITER).length,
       }
     })
@@ -1107,8 +1113,8 @@ export class MemoryStore {
   setEntryBranches(target, entry, branches, agent) {
     const loc = this.resolveTarget(target, agent)
     const exact = String(entry ?? '').trim()
-    if (!exact) return { ok: false, message: '条目不能为空', target }
-    if (target !== 'key') return { ok: false, message: '分支范围仅适用于 key 轨', target }
+    if (!exact) return { ok: false, message: st('store.emptyEntry'), target }
+    if (target !== 'key') return { ok: false, message: stt('storetail.branchKeyOnly'), target }
     const list = (Array.isArray(branches) ? branches : [])
       .map((b) => String(b).trim())
       .filter((b) => b.length > 0)
@@ -1118,19 +1124,19 @@ export class MemoryStore {
       if (reload.kind === 'drift') {
         return {
           ok: false,
-          message: `拒绝写入：${loc.file} 的内容无法通过记忆工具解析往返。已备份到 ${reload.backup}。请先整理文件再重试。`,
+          message: st('store.driftGuardOp', { file: loc.file, backup: reload.backup }),
           target, backup: reload.backup,
         }
       }
       if (reload.kind === 'read-failed') {
-        return { ok: false, message: '记忆文件存在但无法读取，拒绝写入（防止清空已有记忆）', target }
+        return { ok: false, message: st('store.fileUnreadableWrite'), target }
       }
       const entries = reload.entries
       const index = findExactIndex(entries, exact)
       if (index === -1) {
         return {
           ok: false,
-          message: '条目不存在（可能已被删除，或文件被外部修改）——请刷新列表后重试',
+          message: stt('storetail.entryMissing'),
           target, entries: [...entries],
         }
       }
@@ -1168,28 +1174,28 @@ export class MemoryStore {
   setEntryDshOnly(target, entry, on, agent) {
     const loc = this.resolveTarget(target, agent)
     const exact = String(entry ?? '').trim()
-    if (!exact) return { ok: false, message: '条目不能为空', target }
+    if (!exact) return { ok: false, message: st('store.emptyEntry'), target }
     if (target !== 'memory' && target !== 'user' && target !== 'key') {
-      return { ok: false, message: '「仅 DSH」标记仅适用于 memory / user / key 轨', target }
+      return { ok: false, message: stt('storetail.dshOnlyTrackLimit'), target }
     }
     return withLock(loc.dir, () => {
       const reload = this.reload(target, agent)
       if (reload.kind === 'drift') {
         return {
           ok: false,
-          message: `拒绝写入：${loc.file} 的内容无法通过记忆工具解析往返。已备份到 ${reload.backup}。请先整理文件再重试。`,
+          message: st('store.driftGuardOp', { file: loc.file, backup: reload.backup }),
           target, backup: reload.backup,
         }
       }
       if (reload.kind === 'read-failed') {
-        return { ok: false, message: '记忆文件存在但无法读取，拒绝写入（防止清空已有记忆）', target }
+        return { ok: false, message: st('store.fileUnreadableWrite'), target }
       }
       const entries = reload.entries
       const index = findExactIndex(entries, exact)
       if (index === -1) {
         return {
           ok: false,
-          message: '条目不存在（可能已被删除，或文件被外部修改）——请刷新列表后重试',
+          message: stt('storetail.entryMissing'),
           target, entries: [...entries],
         }
       }
@@ -1223,10 +1229,10 @@ export class MemoryStore {
     const loc = this.resolveTarget(target, agent)
     const exact = String(entry ?? '').trim()
     const newContent = String(content ?? '').trim()
-    if (!exact) return { ok: false, message: '条目不能为空', target }
-    if (!newContent) return { ok: false, message: '内容不能为空（删除条目请用删除按钮）', target }
+    if (!exact) return { ok: false, message: st('store.emptyEntry'), target }
+    if (!newContent) return { ok: false, message: stt('storetail.emptyContentTab'), target }
     if (newContent.includes('§')) {
-      return { ok: false, message: '内容不能包含条目分隔符 §（会破坏记忆文件的分割格式）', target }
+      return { ok: false, message: stt('storetail.sectionDelimiter'), target }
     }
     if (this.injectionScan) {
       const threat = scanThreat(newContent)
@@ -1237,19 +1243,19 @@ export class MemoryStore {
       if (reload.kind === 'drift') {
         return {
           ok: false,
-          message: `拒绝写入：${loc.file} 的内容无法通过记忆工具解析往返（可能被手工编辑或外部进程修改）。已备份到 ${reload.backup}。请先将该文件整理为规范的 § 分隔条目，再重试。`,
+          message: st('store.driftGuardWrite', { file: loc.file, backup: reload.backup }),
           target, backup: reload.backup,
         }
       }
       if (reload.kind === 'read-failed') {
-        return { ok: false, message: '记忆文件存在但无法读取，拒绝写入（防止清空已有记忆）', target }
+        return { ok: false, message: st('store.fileUnreadableWrite'), target }
       }
       const entries = reload.entries
       const index = findExactIndex(entries, exact)
       if (index === -1) {
         return {
           ok: false,
-          message: '条目不存在（可能已被删除，或文件被外部修改）——请刷新列表后重试',
+          message: stt('storetail.entryMissing'),
           target, entries: [...entries],
         }
       }
@@ -1258,7 +1264,7 @@ export class MemoryStore {
       if (head === '') {
         return {
           ok: false,
-          message: '该条目没有可识别的标记前缀（时间戳/tag），无法安全编辑——请用系统工具打开文件手动修改',
+          message: stt('storetail.unrecognizedPrefix'),
           target, entries: [...entries],
         }
       }
@@ -1266,7 +1272,7 @@ export class MemoryStore {
       next[index] = `${head}${newContent}`
       this.write(target, next, agent)
       return {
-        ok: true, message: `已更新条目（${target}）`, target,
+        ok: true, message: stt('storetail.updated', { target }), target,
         entries: [...next], chars: next.join(ENTRY_DELIMITER).length,
       }
     })
@@ -1405,9 +1411,9 @@ export class ArchiveStore {
     return withLock(lockDir, () => {
       const entries = this.entriesOf(target, cwd)
       const matches = entries.filter((entry) => entry.includes(match))
-      if (matches.length === 0) return { ok: false, message: `归档中没有条目包含片段 "${match}"` }
+      if (matches.length === 0) return { ok: false, message: stt('storetail.archiveNoMatch', { match }) }
       if (matches.length > 1) {
-        return { ok: false, message: `片段 "${match}" 匹配到 ${matches.length} 个归档条目，请用更精确的片段` }
+        return { ok: false, message: stt('storetail.archiveMultiMatch', { match, count: matches.length }) }
       }
       const next = entries.filter((entry) => !entry.includes(match))
       const path = this.fileOf(target, cwd)
@@ -1424,7 +1430,7 @@ export class ArchiveStore {
       const entries = this.entriesOf(target, cwd)
       const index = entries.indexOf(content)
       if (index === -1) {
-        return { ok: false, message: '归档条目不存在（可能已被删除）——请刷新列表后重试' }
+        return { ok: false, message: stt('storetail.archiveEntryMissing') }
       }
       const next = [...entries]
       next.splice(index, 1)

--- a/lib/store.js
+++ b/lib/store.js
@@ -843,7 +843,7 @@ export class MemoryStore {
         : entries.includes(stamped)
       if (dup) {
         return {
-          ok: true, message: st('store.duplicate'), target,
+          ok: true, duplicate: true, message: st('store.duplicate'), target,
           entries: [...entries], chars: this.charsOf(target, agent),
         }
       }

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -23,6 +23,10 @@ import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from 'nod
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { isProjectSyncEnabled, projectHash, readProvenance, withLock } from '../store.js'
+import { translate, getLocale, getActiveLocale, SYNC_DICT } from '../i18n.js'
+
+/** Translate through SYNC_DICT in the active host locale. */
+const sxt = (key, params) => translate(SYNC_DICT, key, params, getLocale())
 import { locateLegacyDir, normalizeRemoteUrl, resolveMainRemote, resolveProjectId, sanitizeRemoteUrl } from './identity.js'
 import { countConflicts, CONFLICTS_FILE, parseConflicts, resolveConflict } from './worker.js'
 import { deviceBConnect, ensureMemoryRepo, MODE_A_BRANCH, resolveFilesetFiles, sharedBranchFor } from './repo.js'
@@ -64,6 +68,9 @@ export function spawnWorker(args) {
     //    granted"。删除后 gh 回退到自身 OAuth 凭据（gh auth login 存储）。
     delete env.GH_TOKEN
     delete env.GITHUB_TOKEN
+    // Locale propagation: the worker is a separate process — it cannot see the
+    // parent's setLocale(). Hand the active locale down through DSH_LOCALE.
+    env.DSH_LOCALE = getActiveLocale()
     const child = spawn(process.execPath, [SCRIPT_PATH, ...args], { stdio: ['ignore', 'pipe', 'pipe'], env })
     let stdout = ''
     let stderr = ''
@@ -78,13 +85,13 @@ export function spawnWorker(args) {
 function parseWorkerOutput(run) {
   const lines = String(run.stdout ?? '').trim().split('\n').filter((l) => l.trim() !== '')
   if (lines.length === 0) {
-    return { ok: false, code: run.code ?? 1, message: `worker 无输出${run.stderr ? `（${run.stderr.trim().split('\n')[0]}）` : ''}` }
+    return { ok: false, code: run.code ?? 1, message: sxt('sync.workerNoOutput', { tail: run.stderr ? sxt('sync.workerParen', { detail: run.stderr.trim().split('\n')[0] }) : '' }) }
   }
   try {
     const parsed = JSON.parse(lines[lines.length - 1])
     return { ok: parsed.ok === true, code: parsed.code ?? (parsed.ok ? 0 : 1), ...parsed }
   } catch {
-    return { ok: false, code: run.code ?? 1, message: `worker 输出无法解析：${lines[lines.length - 1]}` }
+    return { ok: false, code: run.code ?? 1, message: sxt('sync.workerUnparseable', { line: lines[lines.length - 1] }) }
   }
 }
 
@@ -358,7 +365,7 @@ export function installMemorySync(ctx, deps) {
             projectOptIn(info.provenance)
             writeFileSync(join(info.dir, 'PROVENANCE'), `${JSON.stringify(info.provenance)}\n`)
           }
-          return { kind: 'success', text: '本项目已启用同步' }
+          return { kind: 'success', text: sxt('sync.projectOn') }
         }
         // 关闭：写 PROVENANCE.enabled=false（记忆文件/仓库全保留）
         const info = projectSyncInfo(config, cwd)
@@ -366,12 +373,12 @@ export function installMemorySync(ctx, deps) {
           info.provenance.enabled = false
           writeFileSync(join(info.dir, 'PROVENANCE'), `${JSON.stringify(info.provenance)}\n`)
         }
-        return { kind: 'success', text: '本项目已停用同步（记忆完整保留，可随时重新启用）' }
+        return { kind: 'success', text: sxt('sync.projectOff') }
       },
       /** 轨级开关（三层开关第 3 层）：一期唯一轨=项目记忆。 */
       setTrack(cwd, on) {
         const info = projectSyncInfo(config, cwd)
-        if (info.provenance === null) return { kind: 'error', text: '项目尚未初始化——先启用本项目同步' }
+        if (info.provenance === null) return { kind: 'error', text: sxt('sync.notInitialized') }
         const meta = { ...info.provenance, tracks: { ...(info.provenance.tracks ?? {}), project: on === true } }
         writeFileSync(join(info.dir, 'PROVENANCE'), `${JSON.stringify(meta)}\n`)
         return { kind: 'success', text: on ? '项目记忆轨已纳入同步' : '项目记忆轨已退出同步（该轨保留本地，不再对账）' }
@@ -422,10 +429,10 @@ export function installMemorySync(ctx, deps) {
       /** 全局轨开关（memory/user/daily/todo）。 */
       setGlobalTrack(track, on) {
         const TRACKS = ['memory', 'user', 'daily', 'todo']
-        if (!TRACKS.includes(track)) return { kind: 'error', text: `未知全局轨 "${track}"（应为 memory/user/daily/todo）` }
+        if (!TRACKS.includes(track)) return { kind: 'error', text: sxt('sync.badGlobalTrack', { track }) }
         const outcome = updateGlobalTracks(config.memoryDir, (tracks) => ({ ...tracks, [track]: on === true }))
         if (!outcome.ok) return { kind: 'error', text: outcome.message }
-        return { kind: 'success', text: `全局${trackLabel(track)}同步已${on ? '开启' : '关闭'}` }
+        return { kind: 'success', text: sxt('sync.globalToggled', { track: trackLabel(track), state: on ? sxt('sync.stateOn') : sxt('sync.stateOff') }) }
       },
       /** 全局轨同步（逐个启用轨对账；push=true 即用户显式同意推送）。 */
       /** 全局轨同步（逐个启用轨对账；push=true 即用户显式同意推送）。
@@ -433,7 +440,7 @@ export function installMemorySync(ctx, deps) {
        *  绝不整体报 success。 */
       async globalSync(push) {
         const gMeta = readProvenance(config.memoryDir)
-        if (gMeta === null) return { kind: 'error', text: '全局记忆仓库尚未初始化——先在下方填共享记忆仓库地址初始化' }
+        if (gMeta === null) return { kind: 'error', text: sxt('sync.globalRepoMissing') }
         const results = []
         let failed = 0
         for (const fileset of GLOBAL_FILESET_KEYS) {
@@ -444,7 +451,7 @@ export function installMemorySync(ctx, deps) {
           if (!out.ok) failed += 1
           results.push(`${trackLabel(track)}：${out.ok ? (out.message ?? '完成') : out.message}`)
         }
-        if (results.length === 0) return { kind: 'error', text: '未开启任何全局轨——先开启要同步的轨（全局记忆/用户档案/每日日志/待办）' }
+        if (results.length === 0) return { kind: 'error', text: sxt('sync.noGlobalTracks') }
         const head = failed > 0
           ? `${push ? '全局轨同步并推送' : '全局轨同步'}：${failed} 个轨失败（其余成功）`
           : `${push ? '全局轨同步并推送完成' : '全局轨同步完成'}`
@@ -466,10 +473,10 @@ export function installMemorySync(ctx, deps) {
           // 停用：只写 enabled=false，不删任何数据（PROVENANCE 原子写）
           const outcome = updateGlobalEnabled(config.memoryDir, false)
           if (!outcome.ok) return { kind: 'error', text: outcome.message }
-          return { kind: 'success', text: '共享记忆库已停用（数据与地址保留，可随时重新启用）' }
+          return { kind: 'success', text: sxt('sync.sharedDisabled') }
         }
         const trimmed = String(url ?? '').trim()
-        if (trimmed === '') return { kind: 'error', text: '共享记忆仓库地址不能为空' }
+        if (trimmed === '') return { kind: 'error', text: sxt('sync.emptyRepoUrl') }
         // 网络/初始化走 sync-worker 子进程（主进程零阻塞）
         const gInit = await spawnWorker(['global-init', config.memoryDir, trimmed])
         const gOut = parseWorkerOutput(gInit)
@@ -505,14 +512,22 @@ async function initGlobalRepo(memoryDir, url) {
 }
 
 /** 全局轨开关状态文本（status 用）。 */
-function renderGlobalTracks(tracks) {
-  const names = [['memory', '全局记忆'], ['user', '用户档案'], ['daily', '每日日志'], ['todo', '待办（生活/工作/每日）']]
-  return names.map(([k, label]) => `${label}：${tracks[k] === true ? '开' : '关'}`).join('；')
+const TRACK_I18N = {
+  'sync.track.memory': ['全局记忆', 'global memory'],
+  'sync.track.user': ['用户档案', 'user profile'],
+  'sync.track.daily': ['每日日志', 'daily log'],
+  'sync.track.todo': ['待办（生活/工作/每日）', 'todos (life/work/daily)'],
+  'sync.trackOn': ['开', 'on'],
+  'sync.trackOff': ['关', 'off'],
 }
-
-/** 全局轨显示名（命令/UI 文案）。 */
+/** Localized display name for one global track. */
 function trackLabel(track) {
-  return { memory: '全局记忆', user: '用户档案', daily: '每日日志', todo: '待办（生活/工作/每日）' }[track] ?? track
+  const hit = translate(TRACK_I18N, `sync.track.${track}`, undefined, getLocale())
+  return hit === `sync.track.${track}` ? track : hit
+}
+function renderGlobalTracks(tracks) {
+  const names = ['memory', 'user', 'daily', 'todo']
+  return names.map((k) => `${trackLabel(k)}：${translate(TRACK_I18N, tracks[k] === true ? 'sync.trackOn' : 'sync.trackOff', undefined, getLocale())}`).join('；')
 }
 
 /**
@@ -528,7 +543,7 @@ function updateGlobalTracks(memoryDir, mutate) {
   withLock(memoryDir, () => {
     const gMeta = readProvenance(memoryDir)
     if (gMeta === null) {
-      result = { ok: false, message: '全局记忆仓库尚未初始化——先在下方填共享记忆仓库地址初始化' }
+      result = { ok: false, message: sxt('sync.globalRepoMissing') }
       return
     }
     gMeta.tracks = mutate({ ...(gMeta.tracks ?? {}) })
@@ -554,7 +569,7 @@ function updateGlobalEnabled(memoryDir, enabled) {
   withLock(memoryDir, () => {
     const gMeta = readProvenance(memoryDir)
     if (gMeta === null) {
-      result = { ok: false, message: '共享记忆库尚未初始化——先保存仓库地址' }
+      result = { ok: false, message: sxt('sync.sharedNotInit') }
       return
     }
     gMeta.enabled = enabled === true
@@ -610,7 +625,7 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
         probeUrl = identity.remoteUrl ?? existingOrigin // 切回主仓库（无主仓库时保持现有 origin）
       }
       if (!probeUrl) {
-        return { kind: 'error', text: '当前项目没有可共享的 git 远端——请先为主仓库配置 remote（或在下方填共享记忆仓库地址）' }
+        return { kind: 'error', text: sxt('sync.noGitRemote') }
       }
       // 切换检测：目标远端与现有 origin 不同 → set-url + 更新 PROVENANCE，
       // 本地记忆完整保留，由用户显式 sync 完成首次对账（绝不假成功）
@@ -619,7 +634,7 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
       if (switching) {
         const setUrl = runGitSync(dir, ['remote', 'set-url', 'origin', sanitizeRemoteUrl(probeUrl)])
         if (setUrl === null) {
-          return { kind: 'error', text: '切换记忆远端失败：remote set-url 未成功（本地记忆未受影响）' }
+          return { kind: 'error', text: sxt('sync.switchRemoteFailed') }
         }
       }
       // 分支决策（worker 子进程，网络命令不进主进程）：候选
@@ -645,7 +660,7 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
           }
           applyRuntimePatch({ syncEnabled: true })
           const gNote = await initGlobalRepo(config.memoryDir, url)
-          return { kind: 'success', text: `记忆远端已切换（${probeUrl}，分支 ${branch}）。本地记忆完整保留——点「同步」完成首次对账（推送需点「同步并推送」）${gNote}` }
+          return { kind: 'success', text: sxt('sync.remoteSwitched', { url: probeUrl, branch, note: gNote }) }
         }
         // PROVENANCE 缺失（异常）→ 落到正常初始化流程兜底
       }
@@ -672,7 +687,7 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
           return legacy === null ? '' : `；注意：发现旧记忆目录 ${legacy}（尚未并入，可在记忆同步 Tab 查看）`
         })()
         const gNote = await initGlobalRepo(config.memoryDir, url)
-        return { kind: 'success', text: `已接入远端记忆（${branch}）：${connect.message}。点「同步」拉取合并${legacyWarn}${gNote}` }
+        return { kind: 'success', text: sxt('sync.connected', { branch, message: connect.message, tail: `${legacyWarn}${gNote}` }) }
       }
       const boot = await ensureMemoryRepo({ dir, memoryDir: config.memoryDir, cwd, projectId: identity.id, displayName: identity.displayName, remoteUrl: probeUrl, remoteBranch: branch })
       if (!boot.ok) return { kind: 'error', text: boot.message }
@@ -689,16 +704,16 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
         ? '远端尚无该分支——点「同步并推送」完成首次推送（推送需你同意）'
         : '点「同步」开始对账'
       const gNote = await initGlobalRepo(config.memoryDir, url)
-      return { kind: 'success', text: `记忆同步初始化完成（${branch}）：${boot.message}。${pushHint}${gNote}` }
+      return { kind: 'success', text: sxt('sync.setupDone', { branch, message: boot.message, pushHint, note: gNote }) }
     }
 
     case 'sync': {
       if (!existsSync(join(dir, '.git'))) {
-        return { kind: 'error', text: '当前项目尚未初始化同步——请先点「开始同步」' }
+        return { kind: 'error', text: sxt('sync.needSetupFirst') }
       }
       const meta = readProvenance(dir)
       if (meta !== null && meta.enabled === false) {
-        return { kind: 'error', text: '本项目已停用同步（记忆保留本地）——到记忆同步 Tab 重新启用' }
+        return { kind: 'error', text: sxt('sync.offNeedReenable') }
       }
       if (meta !== null && meta.tracks?.project === false) {
         // 三态切换已取代旧「项目记忆轨」勾选开关（2026-08-11 用户拍板：
@@ -733,17 +748,17 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
       const TRACKS = new Set(['memory', 'user', 'daily', 'todo'])
       if (sub === 'on' || sub === 'off') {
         if (!TRACKS.has(trackName)) {
-          return { kind: 'error', text: '用法：global on|off <memory|user|daily|todo>' }
+          return { kind: 'error', text: sxt('sync.globalUsage') }
         }
         // 原子更新（Codex P2-1：锁内读改写 + tmp+rename）
         const outcome = updateGlobalTracks(config.memoryDir, (tracks) => ({ ...tracks, [trackName]: sub === 'on' }))
         if (!outcome.ok) return { kind: 'error', text: outcome.message }
         const tracks = readProvenance(config.memoryDir)?.tracks ?? {}
-        return { kind: 'success', text: `全局${trackLabel(trackName)}同步已${sub === 'on' ? '开启' : '关闭'}（${renderGlobalTracks(tracks)}）` }
+        return { kind: 'success', text: sxt('sync.globalStatusToggled', { track: trackLabel(trackName), state: sub === 'on' ? sxt('sync.stateOn') : sxt('sync.stateOff'), tracks: renderGlobalTracks(tracks) }) }
       }
       if (sub === 'sync') {
         const gMeta = readProvenance(config.memoryDir)
-        if (gMeta === null) return { kind: 'error', text: '全局记忆仓库尚未初始化——先在下方填共享记忆仓库地址初始化' }
+        if (gMeta === null) return { kind: 'error', text: sxt('sync.globalRepoMissing') }
         const push = rest.includes('--push')
         // 逐个启用轨对账（每轨独立分支，互不干扰）；失败聚合（Codex P1-5）：
         // 任一轨失败如实报"部分失败"，绝不整体报 success
@@ -757,7 +772,7 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
           if (!out.ok) failed += 1
           results.push(`${trackLabel(track)}：${out.ok ? (out.message ?? '完成') : out.message}`)
         }
-        if (results.length === 0) return { kind: 'error', text: '未开启任何全局轨——先打开要同步的轨开关' }
+        if (results.length === 0) return { kind: 'error', text: sxt('sync.noGlobalTracksSwitches') }
         const head = failed > 0
           ? `${push ? '全局轨同步并推送' : '全局轨同步'}：${failed} 个轨失败（其余成功）`
           : `${push ? '全局轨同步并推送完成' : '全局轨同步完成'}`
@@ -766,7 +781,7 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
       if (sub === 'status') {
         const g = globalSyncStatus(config.memoryDir)
         if (!g.initialized) {
-          return { kind: 'success', text: '全局记忆同步未初始化——全局记忆（用户档案/每日日志/待办）仅共享记忆仓库可用：先填共享记忆仓库地址初始化' }
+          return { kind: 'success', text: sxt('sync.globalNotInitShort') }
         }
         const lines = [
           `全局记忆远端：${g.url}`,
@@ -778,7 +793,7 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
         ]
         return { kind: 'success', text: lines.join('\n') }
       }
-      return { kind: 'error', text: '用法：global status | global on|off <memory|user|daily|todo> | global sync [--push]' }
+      return { kind: 'error', text: sxt('sync.globalUsageLong') }
     }
 
     case 'off': {
@@ -788,19 +803,19 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
       // **轨位联动（三态取代旧轨开关）**：不启用 = 原来的"关" = 项目记忆轨
       // 也退出（tracks.project=false），与 setup 的 projectOptIn 复位互逆。
       const meta = readProvenance(dir)
-      if (meta === null) return { kind: 'error', text: '当前项目尚未初始化同步（无需停用）' }
+      if (meta === null) return { kind: 'error', text: sxt('sync.nothingToDisable') }
       meta.enabled = false
       meta.tracks = { ...(meta.tracks ?? {}), project: false }
       writeFileSync(join(dir, 'PROVENANCE'), `${JSON.stringify(meta)}\n`)
-      return { kind: 'success', text: '本项目已停用同步：记忆完整保留在本机，不再对账；重新启用随时可继续（记忆同步 Tab）' }
+      return { kind: 'success', text: sxt('sync.disabledLong') }
     }
 
     case 'status': {
       const enabled = getRuntime()?.syncEnabled === true
-      if (!enabled) return { kind: 'success', text: '记忆同步模块未启用——在「Memory Evolve 设置 → 配置」打开' }
+      if (!enabled) return { kind: 'success', text: sxt('sync.moduleDisabled') }
       const info = syncStatusSync(config, cwd)
       if (info === null) {
-        return { kind: 'success', text: `模块已启用，但当前项目未初始化——点下方「开始同步」` }
+        return { kind: 'success', text: sxt('sync.moduleOnProjectNotInit') }
       }
       const remoteName = resolveMainRemote(cwd)?.name ?? '?'
       // 记忆远端类型（统一模式）：sync 仓库 origin 与主仓库 remote 归一化
@@ -852,10 +867,10 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
         const index = Number(rest[1])
         const choice = (rest[2] ?? '').toLowerCase()
         if (!Number.isInteger(index) || index < 1) {
-          return { kind: 'error', text: '用法：conflict resolve <编号> ours | theirs | both [fileset]（编号来自 conflict list）' }
+          return { kind: 'error', text: sxt('sync.resolveUsageHint') }
         }
         if (!['ours', 'theirs', 'both'].includes(choice)) {
-          return { kind: 'error', text: '用法：conflict resolve <编号> ours | theirs | both [fileset]' }
+          return { kind: 'error', text: sxt('sync.resolveUsage') }
         }
         const result = await resolveConflict({
           dir: conflictDir, index, choice, fileset,
@@ -867,25 +882,25 @@ export async function handleCommand(op, rest, cwd, { config, getRuntime, applyRu
         return { kind: 'success', text: `${result.message}${result.remaining > 0 ? `；剩余冲突 ${result.remaining} 条` : '；冲突已全部解决'}` }
       }
       if (sub !== 'list') {
-        return { kind: 'error', text: '用法：conflict list [fileset] | conflict resolve <编号> ours | theirs | both [fileset]' }
+        return { kind: 'error', text: sxt('sync.conflictUsage') }
       }
       const path = join(conflictDir, conflictsFileFor(fileset))
-      if (!existsSync(path)) return { kind: 'success', text: '没有待处理的同步冲突。' }
+      if (!existsSync(path)) return { kind: 'success', text: sxt('sync.noConflicts') }
       return { kind: 'success', text: readFileSync(path, 'utf8') }
     }
 
     case 'migrate': {
       const legacy = locateLegacyDir(config.memoryDir, cwd, identity.id)
       if (legacy === null) {
-        return { kind: 'success', text: '没有发现可迁移的旧记忆目录（当前身份与历史目录一致）。' }
+        return { kind: 'success', text: sxt('sync.noLegacyDir') }
       }
       return {
         kind: 'success',
-        text: `发现旧记忆目录：${legacy}\n→ 点「开始同步」会自动迁移到新目录 ${dir}（记入迁移日志）。`,
+        text: sxt('sync.legacyFound', { legacy, dir }),
       }
     }
 
     default:
-      return { kind: 'error', text: `未知子命令 "${op}"。用法：setup [url] | sync [--push] | off | status | conflict list | migrate` }
+      return { kind: 'error', text: sxt('sync.unknownSub', { op }) }
   }
 }

--- a/lib/sync/repo.js
+++ b/lib/sync/repo.js
@@ -21,6 +21,10 @@
  */
 
 import { createHash } from 'node:crypto'
+import { translate, getLocale, SYNC_REPO_DICT } from '../i18n.js'
+
+/** Translate through SYNC_REPO_DICT in the active host locale. */
+const srt = (key, params) => translate(SYNC_REPO_DICT, key, params, getLocale())
 import { spawn } from 'node:child_process'
 import { closeSync, copyFileSync, existsSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -95,7 +99,7 @@ export async function decideModeBBranch({ dir, remoteUrl, projectId }) {
   const candidates = [sharedBranch, MODE_A_BRANCH, 'main']
   const probe = await runGit(dir, ['ls-remote', remoteUrl, ...candidates.map((b) => `refs/heads/${b}`)], { network: true })
   if (!probe.ok) {
-    return { ok: false, kind: 'error', branch: null, message: `无法连接记忆远端（${classifyRemoteError(probe.stderr)}）：${probe.stderr.trim().split('\n')[0] ?? ''}。请检查网络/凭证后重试` }
+    return { ok: false, kind: 'error', branch: null, message: srt('syncr.probeFailed', { reason: classifyRemoteError(probe.stderr), detail: probe.stderr.trim().split('\n')[0] ?? '' }) }
   }
   // 解析存在性：输出行 "hash\trefs/heads/<名>"
   const present = new Set()
@@ -107,7 +111,7 @@ export async function decideModeBBranch({ dir, remoteUrl, projectId }) {
   // 专属分支存在 → 直接续接（分支名即本项目身份；deviceBConnect 的
   // expectedProjectId 校验仍会兜底）
   if (present.has(sharedBranch)) {
-    return { ok: true, kind: 'shared', branch: sharedBranch, message: `远端已有本项目的专属分支 ${sharedBranch}，直接接入` }
+    return { ok: true, kind: 'shared', branch: sharedBranch, message: srt('syncr.adoptShared', { branch: sharedBranch }) }
   }
 
   // ── 2. 老分支兼容：dsh-shared/memory（老模式 A）→ main（老模式 B）──
@@ -149,20 +153,20 @@ export async function decideModeBBranch({ dir, remoteUrl, projectId }) {
       // 存在但拉不到内容，静默跳过会切新分支遗弃旧历史（split-brain）——
       // 如实报错让用户处理
       if (!fetch.ok && belongs === false && fetch.stderr.trim() !== '') {
-        return { ok: false, kind: 'error', branch: null, message: `无法读取远端分支 ${legacy} 的内容（${fetch.stderr.trim().split('\n')[0] ?? ''}）——已停止初始化，请检查远端后重试` }
+        return { ok: false, kind: 'error', branch: null, message: srt('syncr.fetchLegacyFail', { branch: legacy, detail: fetch.stderr.trim().split('\n')[0] ?? '' }) }
       }
     } catch (error) {
-      return { ok: false, kind: 'error', branch: null, message: `git 初始化失败：${error?.message ?? String(error)}` }
+      return { ok: false, kind: 'error', branch: null, message: srt('syncr.gitInitFail', { detail: error?.message ?? String(error) }) }
     }
     if (belongs) {
       const kind = legacy === MODE_A_BRANCH ? 'legacy-memory' : 'legacy-main'
-      return { ok: true, kind, branch: legacy, message: `远端分支 ${legacy} 是本项目的记忆（老配置）——继续使用，零迁移` }
+      return { ok: true, kind, branch: legacy, message: srt('syncr.legacyContinue', { branch: legacy }) }
     }
   }
 
   // ── 3. 全部不存在/不匹配 → 全新：用专属分支（远端可能已有其他项目）──
-  const others = present.size > 0 ? '远端已有其他项目的分支——' : '全新记忆远端——'
-  return { ok: true, kind: 'fresh', branch: sharedBranch, message: `${others}本项目使用专属分支 ${sharedBranch}` }
+  const others = present.size > 0 ? srt('syncr.othersPresent') : srt('syncr.freshRemote')
+  return { ok: true, kind: 'fresh', branch: sharedBranch, message: srt('syncr.freshBranch', { others, branch: sharedBranch }) }
 }
 
 /** 项目待办文件名（2026-08-11 统一模式：并入项目记忆轨同步）。
@@ -354,7 +358,7 @@ export async function ensureMemoryRepo({ dir, memoryDir, cwd, projectId, display
       // 导致记忆分裂
       return {
         ok: false,
-        message: `记忆目录迁移失败：${error?.message ?? String(error)}。请人工检查 ${memoryDir}/projects/ 下是否有两个同项目目录后重试。`,
+        message: srt('syncr.migrateFail', { detail: error?.message ?? String(error), memoryDir }),
         committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null,
       }
     }
@@ -373,11 +377,11 @@ export async function ensureMemoryRepo({ dir, memoryDir, cwd, projectId, display
   if (!init.ok) {
     const initPlain = await runGit(dir, ['init', '-q'])
     if (!initPlain.ok) {
-      return { ok: false, message: `git init 失败（${initPlain.stderr.trim().split('\n')[0] ?? ''}）——请检查 git 是否可用`, committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
+      return { ok: false, message: srt('syncr.initFail', { detail: initPlain.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
     }
     const sym = await runGit(dir, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
     if (!sym.ok) {
-      return { ok: false, message: `无法设置默认分支 main（${sym.stderr.trim().split('\n')[0] ?? ''}）`, committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
+      return { ok: false, message: srt('syncr.mainBranchFail', { detail: sym.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
     }
   }
 
@@ -436,10 +440,10 @@ export async function ensureMemoryRepo({ dir, memoryDir, cwd, projectId, display
     try {
       meta = JSON.parse(existing)
     } catch {
-      return { ok: false, message: 'PROVENANCE 已存在但无法解析（JSON 损坏）——请人工检查后重试', committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
+      return { ok: false, message: srt('syncr.provenanceCorrupt'), committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
     }
     if (typeof meta.projectId === 'string' && meta.projectId !== projectId) {
-      return { ok: false, message: `目录身份不匹配：现有 PROVENANCE 属于项目 ${meta.projectId}（${meta.displayName ?? ''}），当前解析为 ${projectId}。目录可能被误用或接错，已停止初始化`, committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
+      return { ok: false, message: srt('syncr.identityMismatch', { existing: meta.projectId, displayName: meta.displayName ?? '', current: projectId }), committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
     }
   } else {
     // enabled/tracks：三层开关的项目级与轨级位（2026-08-11 用户拍板）——
@@ -461,7 +465,7 @@ export async function ensureMemoryRepo({ dir, memoryDir, cwd, projectId, display
     const stamp = new Date().toISOString().slice(0, 10)
     const commit = await runGit(dir, ['commit', '-q', '-m', `memory: initial import ${stamp}`])
     if (!commit.ok) {
-      return { ok: false, message: `首次提交失败：${commit.stderr.trim().split('\n')[0] ?? ''}`, committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
+      return { ok: false, message: srt('syncr.commitFail', { detail: commit.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
     }
     report.committed = true
   }
@@ -472,7 +476,7 @@ export async function ensureMemoryRepo({ dir, memoryDir, cwd, projectId, display
   if (!origin.ok || origin.stdout.trim() === '') {
     const add = await runGit(dir, ['remote', 'add', 'origin', sanitizeRemoteUrl(remoteUrl)])
     if (!add.ok) {
-      return { ok: false, message: `remote 挂载失败：${add.stderr.trim().split('\n')[0] ?? ''}`, committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
+      return { ok: false, message: srt('syncr.remoteAddFail', { detail: add.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: 0, migratedFrom: null, remoteBranchExists: null }
     }
   }
 
@@ -519,14 +523,14 @@ export async function deviceBConnect({ dir, remoteUrl, remoteBranch, expectedPro
     return {
       ok: false,
       mode: 'error',
-      message: `无法连接远端记忆仓库（${reason}）：${probe.stderr.trim().split('\n')[0] ?? ''}。已跳过初始化，本地记忆不受影响；请检查网络/凭证后重试。`,
+      message: srt('syncr.remoteUnreachable', { reason, detail: probe.stderr.trim().split('\n')[0] ?? '' }),
     }
   }
 
   if (probe.stdout.trim() === '') {
     // 分支不存在 → 走设备 A 初始化（本地建仓 + 首次提交；远端分支由首次
     // push 创建——push 需用户显式触发）
-    return { ok: true, mode: 'bootstrap-needed', message: `远端尚无 ${remoteBranch} 分支，将按新设备初始化` }
+    return { ok: true, mode: 'bootstrap-needed', message: srt('syncr.bootstrapNeeded', { branch: remoteBranch }) }
   }
 
   // ── 已接入幂等（Kimi P1-4 修复）：本地已是同一项目的已初始化仓库
@@ -539,7 +543,7 @@ export async function deviceBConnect({ dir, remoteUrl, remoteBranch, expectedPro
       try {
         const localMeta = JSON.parse(readFileSync(localProvPath, 'utf8').trim())
         if (localMeta.projectId === expectedProjectId) {
-          return { ok: true, mode: 'adopt', message: '本项目已接入（重复 setup 幂等，无需重新初始化）' }
+          return { ok: true, mode: 'adopt', message: srt('syncr.idempotentAdopt') }
         }
       } catch { /* 本地 PROVENANCE 损坏 → 走正常接入流程（严格校验会拒绝） */ }
     }
@@ -554,7 +558,7 @@ export async function deviceBConnect({ dir, remoteUrl, remoteBranch, expectedPro
     return {
       ok: false,
       mode: 'error',
-      message: `目标目录 ${dir} 已有记忆内容（${existing.slice(0, 5).join('、')}${existing.length > 5 ? '…' : ''}）——为避免覆盖本地记忆，请先清空目录或人工处理后再接入`,
+      message: srt('syncr.dirNotEmpty', { dir, files: `${existing.slice(0, 5).join('、')}${existing.length > 5 ? '…' : ''}` }),
     }
   }
 
@@ -564,7 +568,7 @@ export async function deviceBConnect({ dir, remoteUrl, remoteBranch, expectedPro
   if (!init.ok) {
     await runGit(dir, ['init', '-q'])
     const sym = await runGit(dir, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
-    if (!sym.ok) return { ok: false, mode: 'error', message: `git init 失败：${sym.stderr.trim().split('\n')[0] ?? ''}` }
+    if (!sym.ok) return { ok: false, mode: 'error', message: srt('syncr.gitInitFailShort', { detail: sym.stderr.trim().split('\n')[0] ?? '' }) }
   }
   // **Windows 换行事故修复（2026-08-11 实测）：必须在 checkout 之前**设置
   // 仓库级 core.autocrlf false——Windows Git 默认 autocrlf=true（system 级），
@@ -575,11 +579,11 @@ export async function deviceBConnect({ dir, remoteUrl, remoteBranch, expectedPro
   const originCheck = await runGit(dir, ['remote', 'get-url', 'origin'])
   if (!originCheck.ok || originCheck.stdout.trim() === '') {
     const add = await runGit(dir, ['remote', 'add', 'origin', sanitizeRemoteUrl(remoteUrl)])
-    if (!add.ok) return { ok: false, mode: 'error', message: `remote 挂载失败：${add.stderr.trim().split('\n')[0] ?? ''}` }
+    if (!add.ok) return { ok: false, mode: 'error', message: srt('syncr.remoteAddFailShort', { detail: add.stderr.trim().split('\n')[0] ?? '' }) }
   }
   const fetch = await runGit(dir, ['fetch', 'origin', `refs/heads/${remoteBranch}:refs/remotes/origin/${remoteBranch}`], { network: true })
   if (!fetch.ok) {
-    return { ok: false, mode: 'error', message: `拉取远端记忆失败：${fetch.stderr.trim().split('\n')[0] ?? ''}` }
+    return { ok: false, mode: 'error', message: srt('syncr.fetchFail', { detail: fetch.stderr.trim().split('\n')[0] ?? '' }) }
   }
   // ── 远端 PROVENANCE 校验（审查 P1-10 → Codex 终审 P0-1 严格化）：接入前
   //    确认远端确实是本项目，防止 origin 指错/复用独立仓库时把别家记忆接进
@@ -590,21 +594,21 @@ export async function deviceBConnect({ dir, remoteUrl, remoteBranch, expectedPro
   if (typeof expectedProjectId === 'string') {
     const remoteProvenance = await runGit(dir, ['show', `refs/remotes/origin/${remoteBranch}:PROVENANCE`])
     if (!remoteProvenance.ok) {
-      return { ok: false, mode: 'error', message: `远端分支 ${remoteBranch} 没有 PROVENANCE（身份缺失）——无法确认归属本项目，已拒绝接入（防串项目）。请人工检查远端分支后重试` }
+      return { ok: false, mode: 'error', message: srt('syncr.noProvenance', { branch: remoteBranch }) }
     }
     let meta = null
     try {
       meta = JSON.parse(remoteProvenance.stdout.trim())
     } catch {
-      return { ok: false, mode: 'error', message: `远端分支 ${remoteBranch} 的 PROVENANCE 损坏（无法解析 JSON）——已拒绝接入（防串项目）。请人工检查远端分支后重试` }
+      return { ok: false, mode: 'error', message: srt('syncr.provenanceBroken', { branch: remoteBranch }) }
     }
     if (typeof meta.projectId !== 'string' || meta.projectId !== expectedProjectId) {
-      return { ok: false, mode: 'error', message: `远端记忆属于项目 ${meta.projectId ?? '未知'}（${meta.displayName ?? ''}），与当前项目 ${expectedProjectId} 不匹配——疑似接错了分支/仓库，已拒绝接入` }
+      return { ok: false, mode: 'error', message: srt('syncr.identityMismatchRemote', { projectId: meta.projectId ?? '未知', displayName: meta.displayName ?? '', expected: expectedProjectId }) }
     }
   }
   const checkout = await runGit(dir, ['checkout', '-B', 'main', `refs/remotes/origin/${remoteBranch}`])
   if (!checkout.ok) {
-    return { ok: false, mode: 'error', message: `检出远端记忆失败：${checkout.stderr.trim().split('\n')[0] ?? ''}` }
+    return { ok: false, mode: 'error', message: srt('syncr.checkoutFail', { detail: checkout.stderr.trim().split('\n')[0] ?? '' }) }
   }
   // 仓库级兜底身份（--local，缺哪个补哪个——审查 P1-11）
   const localName = await runGit(dir, ['config', '--local', '--get', 'user.name'])
@@ -615,7 +619,7 @@ export async function deviceBConnect({ dir, remoteUrl, remoteBranch, expectedPro
   if (!localEmail.ok || localEmail.stdout.trim() === '') {
     await runGit(dir, ['config', '--local', 'user.email', REPO_USER.email])
   }
-  return { ok: true, mode: 'adopt', message: `已接入远端记忆（${remoteBranch}）` }
+  return { ok: true, mode: 'adopt', message: srt('syncr.adopted', { branch: remoteBranch }) }
 }
 
 /* ---------------- 全局记忆仓库（全局轨，2026-08-11 本期实现） ---------------- */
@@ -648,9 +652,9 @@ export async function ensureGlobalRepo({ dir, url }) {
   const init = await runGit(dir, ['init', '-q', '-b', 'main'])
   if (!init.ok) {
     const initPlain = await runGit(dir, ['init', '-q'])
-    if (!initPlain.ok) return { ok: false, message: `全局记忆仓库 git init 失败：${initPlain.stderr.trim().split('\n')[0] ?? ''}`, committed: false, backfilled: 0 }
+    if (!initPlain.ok) return { ok: false, message: srt('syncr.globalInitFail', { detail: initPlain.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: 0 }
     const sym = await runGit(dir, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
-    if (!sym.ok) return { ok: false, message: `无法设置默认分支 main：${sym.stderr.trim().split('\n')[0] ?? ''}`, committed: false, backfilled: 0 }
+    if (!sym.ok) return { ok: false, message: srt('syncr.globalMainFail', { detail: sym.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: 0 }
   }
 
   // ── 2. 仓库级兜底身份（与项目仓库同款）──
@@ -725,7 +729,7 @@ export async function ensureGlobalRepo({ dir, url }) {
   for (const p of [...allFiles, ...STAGE_META]) {
     if (existsSync(join(dir, p))) {
       const add = await runGit(dir, ['add', '-f', '--ignore-errors', '--', p])
-      if (!add.ok) return { ok: false, message: `全局记忆文件 stage 失败（${p}）：${add.stderr.trim().split('\n')[0] ?? ''}`, committed: false, backfilled: report.backfilled }
+      if (!add.ok) return { ok: false, message: srt('syncr.globalStageFail', { path: p, detail: add.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: report.backfilled }
     }
   }
   const staged = await runGit(dir, ['diff', '--cached', '--quiet'])
@@ -733,7 +737,7 @@ export async function ensureGlobalRepo({ dir, url }) {
     const stamp = new Date().toISOString().slice(0, 10)
     const commit = await runGit(dir, ['commit', '-q', '-m', `memory: global initial import ${stamp}`])
     if (!commit.ok) {
-      return { ok: false, message: `全局记忆仓库首次提交失败：${commit.stderr.trim().split('\n')[0] ?? ''}`, committed: false, backfilled: report.backfilled }
+      return { ok: false, message: srt('syncr.globalCommitFail', { detail: commit.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: report.backfilled }
     }
     report.committed = true
   }
@@ -746,14 +750,14 @@ export async function ensureGlobalRepo({ dir, url }) {
   const origin = await runGit(dir, ['remote', 'get-url', 'origin'])
   if (!origin.ok || origin.stdout.trim() === '') {
     const add = await runGit(dir, ['remote', 'add', 'origin', sanitizeRemoteUrl(url)])
-    if (!add.ok) return { ok: false, message: `全局记忆仓库 remote 挂载失败：${add.stderr.trim().split('\n')[0] ?? ''}`, committed: false, backfilled: report.backfilled }
+    if (!add.ok) return { ok: false, message: srt('syncr.globalRemoteAddFail', { detail: add.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: report.backfilled }
   } else {
     const originKey = normalizeRemoteUrl(origin.stdout.trim())
     const urlKey = normalizeRemoteUrl(url)
     const urlChanged = originKey !== undefined && urlKey !== undefined && originKey !== urlKey
     if (urlChanged) {
       const set = await runGit(dir, ['remote', 'set-url', 'origin', sanitizeRemoteUrl(url)])
-      if (!set.ok) return { ok: false, message: `全局记忆仓库 remote 切换失败：${set.stderr.trim().split('\n')[0] ?? ''}`, committed: false, backfilled: report.backfilled }
+      if (!set.ok) return { ok: false, message: srt('syncr.globalRemoteSetFail', { detail: set.stderr.trim().split('\n')[0] ?? '' }), committed: false, backfilled: report.backfilled }
       // 更新 PROVENANCE 身份（新 URL 指纹；轨开关保留）
       const provPath = join(dir, 'PROVENANCE')
       if (existsSync(provPath)) {

--- a/lib/sync/worker.js
+++ b/lib/sync/worker.js
@@ -28,6 +28,10 @@ import { genEntryId, extractEntryId, extractTodoId, TODO_ID_RE } from './entryid
 import { mergeEntries } from './merge.js'
 import { asyncSyncLock, asyncWithLock, extractTodoHeader, isMemoryFile, parseTodoEntries, readTreeFiles, resolveFilesetFiles, runGit, serializeTodoEntries, stagePaths } from './repo.js'
 import { conflictsFileFor, isTodoPath } from './filesets.js'
+import { translate, getLocale, SYNC_WORKER_DICT } from '../i18n.js'
+
+/** Translate through SYNC_WORKER_DICT in the active host locale. */
+const swt = (key, params) => translate(SYNC_WORKER_DICT, key, params, getLocale())
 
 /** CONFLICTS.md 文件名（项目轨侧车；全局轨按 fileset 独立侧车，见 conflictsFileFor）。 */
 export const CONFLICTS_FILE = 'CONFLICTS.md'
@@ -59,21 +63,21 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
 
   // ── 前置检查：目录必须是已初始化的记忆仓库 ──
   if (!existsSync(join(dir, '.git'))) {
-    return { ok: false, code: 1, message: '记忆仓库尚未初始化——请先在记忆同步 Tab 点「开始同步」初始化', committed: false, conflicts: 0, stats: {} }
+    return { ok: false, code: 1, message: swt('syncw.notInit'), committed: false, conflicts: 0, stats: {} }
   }
   // **未解决冲突禁止继续（Codex 二轮 P0-2 数据风险链）**：冲突条目不落工作树
   // （只在侧车），二次 sync 重新合并会把"空工作树"误判为删除、覆盖侧车——
   // 数据永久丢。必须先 resolve 再同步（项目轨与全局轨一视同仁）。
   const pendingConflicts = countConflicts(dir, fileset)
   if (pendingConflicts > 0) {
-    return { ok: false, code: 1, message: `还有 ${pendingConflicts} 条冲突未解决（${conflictsFileFor(fileset)}）——请先在冲突区解决后再同步`, committed: false, conflicts: pendingConflicts, stats: {} }
+    return { ok: false, code: 1, message: swt('syncw.conflictsPending', { count: pendingConflicts, file: conflictsFileFor(fileset) }), committed: false, conflicts: pendingConflicts, stats: {} }
   }
   // 项目级同步开关（三层开关第 2 层，2026-08-11 用户拍板）：enabled=false
   // 的项目拒绝对账（记忆完整保留本地）。全局轨（fileset ≠ project）跳过
   // 项目级检查（全局仓库的开关是各轨 PROVENANCE.tracks，由调用方把关）。
   if (fileset === 'project') {
     if (!isProjectSyncEnabled(dir)) {
-      return { ok: false, code: 1, message: '本项目已停用同步（记忆完整保留本地）——重新启用后继续', committed: false, conflicts: 0, stats: {} }
+      return { ok: false, code: 1, message: swt('syncw.disabledResume'), committed: false, conflicts: 0, stats: {} }
     }
     // 轨级开关（第 3 层）：项目记忆轨退出同步 → 无内容可对账。
     // **兜底语义（2026-08-11 用户拍板三态切换）**：handleCommand 'sync'
@@ -83,7 +87,7 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
     // 保持保守：未显式纳入轨的内容不推送。
     const provenance = readProvenance(dir)
     if (provenance !== null && provenance.tracks?.project === false) {
-      return { ok: false, code: 1, message: '项目记忆轨已退出同步（未选择任何同步内容）', committed: false, conflicts: 0, stats: {} }
+      return { ok: false, code: 1, message: swt('syncw.noTracksSelected'), committed: false, conflicts: 0, stats: {} }
     }
   }
 
@@ -115,7 +119,7 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
   if (!fetch.ok && !remoteMissing) {
     // fetch 失败：不进入合并，本地数据零影响
     const err = fetch.stderr.trim().split('\n')[0] ?? '未知错误'
-    return { ok: false, code: 1, message: `拉取远端记忆失败（${err}）。本地记忆未受影响，请检查网络/凭证后重试`, committed: false, conflicts: 0, stats: {} }
+    return { ok: false, code: 1, message: swt('syncw.pullFail', { err }), committed: false, conflicts: 0, stats: {} }
   }
   if (remoteMissing) {
     const staleTracking = await runGit(dir, ['rev-parse', '--verify', rb])
@@ -123,7 +127,7 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
       // 远端分支被删除/迁移：清理陈旧 tracking ref（保留只会让后续读树
       // 读到过期数据），并如实报错——本地记忆零改动
       await runGit(dir, ['update-ref', '-d', rb])
-      return { ok: false, code: 1, message: `远端分支 ${remoteBranch} 已不存在（本地曾有陈旧跟踪，已清理）。远端记忆可能被删除或迁移——请检查远端后重新初始化`, committed: false, conflicts: 0, stats: {} }
+      return { ok: false, code: 1, message: swt('syncw.branchGone', { branch: remoteBranch }), committed: false, conflicts: 0, stats: {} }
     }
     // 真·首次推送：从未有过 tracking → 远端视为空
   }
@@ -131,7 +135,7 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
   // 远端 ref 存在性（fetch 后应有；首次推送场景远端 ref 缺失是预期的）
   const theirsRef = await runGit(dir, ['rev-parse', '--verify', rb])
   if (!theirsRef.ok && !remoteMissing) {
-    return { ok: false, code: 1, message: `远端分支 ${remoteBranch} 不存在——请先点「开始同步」初始化`, committed: false, conflicts: 0, stats: {} }
+    return { ok: false, code: 1, message: swt('syncw.branchMissing', { branch: remoteBranch }), committed: false, conflicts: 0, stats: {} }
   }
   const headRef = await runGit(dir, ['rev-parse', '--verify', lb])
 
@@ -148,7 +152,7 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
   // 用户人工处理，本地零改动。
   const theirs = await readTreeFiles(dir, rb, fileset)
   if (theirs.invalid.length > 0) {
-    return { ok: false, code: 3, message: `远端记忆数据格式异常（${theirs.invalid[0].path}：${theirs.invalid[0].reason}）——已停止同步，本地记忆未受影响。请人工检查远端分支后重试`, committed: false, conflicts: 0, stats: {} }
+    return { ok: false, code: 3, message: swt('syncw.remoteInvalid', { path: theirs.invalid[0].path, reason: theirs.invalid[0].reason }), committed: false, conflicts: 0, stats: {} }
   }
   let base = { files: {}, provenance: null, invalid: [] }
   // 首次推送场景（远端空）跳过 merge-base：无共同历史可对齐，base 为空
@@ -159,13 +163,13 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
       // 退出码 3，绝不自动覆盖（施工图 §5 阶段 2a）
       return {
         ok: false, code: 3,
-        message: '历史无法对齐（可能被 force 推送或接错了分支）——已停止合并，本地记忆未受影响。请人工检查远端分支后重试',
+        message: swt('syncw.historyDiverged'),
         committed: false, conflicts: 0, stats: {},
       }
     }
     base = await readTreeFiles(dir, mergeBase.stdout.trim(), fileset)
     if (base.invalid.length > 0) {
-      return { ok: false, code: 3, message: `历史数据格式异常（${base.invalid[0].path}：${base.invalid[0].reason}）——已停止合并，本地记忆未受影响。请人工检查后重试`, committed: false, conflicts: 0, stats: {} }
+      return { ok: false, code: 3, message: swt('syncw.baseInvalid', { path: base.invalid[0].path, reason: base.invalid[0].reason }), committed: false, conflicts: 0, stats: {} }
     }
   }
 
@@ -267,7 +271,7 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
   // conflicts 统一为计数（merged.conflicts 是合并器返回的数组）
   const conflictCount = Array.isArray(merged.conflicts) ? merged.conflicts.length : (merged.conflicts ?? 0)
   if (merged.commitError) {
-    return { ok: false, code: 1, message: `合并完成但提交失败：${merged.commitError}。工作树已是合并结果，请重试`, committed: false, conflicts: conflictCount, stats: merged.stats }
+    return { ok: false, code: 1, message: swt('syncw.commitAfterMergeFail', { detail: merged.commitError }), committed: false, conflicts: conflictCount, stats: merged.stats }
   }
 
   // ── 阶段 3（锁外，仅 --push）：显式 refspec；non-ff 不 force ──
@@ -277,7 +281,7 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
   if (push && conflictCount > 0) {
     return {
       ok: false, code: 1,
-      message: `还有 ${conflictCount} 条冲突未解决（${conflictsFileFor(fileset)}）——请先解决冲突再推送，否则远端会缺少冲突条目`,
+      message: swt('syncw.conflictsBeforePush', { count: conflictCount, file: conflictsFileFor(fileset) }),
       committed: merged.committed, conflicts: conflictCount, stats: merged.stats,
     }
   }
@@ -288,13 +292,13 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
       if (/non-fast-forward|fetch first|rejected/i.test(err)) {
         return {
           ok: false, code: 1,
-          message: '推送被拒绝：远端有新提交（non-fast-forward）。请先再点一次「同步」拉取合并后再推，绝不强制推送',
+          message: swt('syncw.pushRejected'),
           committed: merged.committed, conflicts: conflictCount, stats: merged.stats,
         }
       }
       return {
         ok: false, code: 1,
-        message: `推送失败（${err.split('\n')[0] ?? '未知错误'}）。合并结果已安全保存在本地，可稍后重试`,
+        message: swt('syncw.pushFail', { detail: err.split('\n')[0] ?? swt('syncw.unknownError') }),
         committed: merged.committed, conflicts: conflictCount, stats: merged.stats,
       }
     }
@@ -326,7 +330,7 @@ async function runSyncInner({ dir, remoteBranch, push = false, fileset = 'projec
  */
 export async function runStatus({ dir, remoteBranch, localBranch = 'main' }) {
   if (!existsSync(join(dir, '.git'))) {
-    return { ok: true, message: '未初始化', status: { initialized: false } }
+    return { ok: true, message: swt('syncw.statusNotInit'), status: { initialized: false } }
   }
   const rb = `refs/remotes/origin/${remoteBranch}`
   const lb = `refs/heads/${localBranch}`
@@ -348,7 +352,7 @@ export async function runStatus({ dir, remoteBranch, localBranch = 'main' }) {
   const conflicts = countConflicts(dir)
   return {
     ok: true,
-    message: `初始化：${theirsRef.ok ? '已接入' : '未接入远端'}`,
+    message: swt('syncw.statusInit', { state: theirsRef.ok ? swt('syncw.connectedState') : swt('syncw.notConnected') }),
     status: { initialized: true, behind, ahead, uncommitted, conflicts },
   }
 }
@@ -480,7 +484,7 @@ function checkProvenance(dir, rb, remoteMissing = false) {
   // 分支存在但 PROVENANCE 缺失 / 空 / 坏 JSON / projectId 不匹配 → 拒绝。
   if (local && typeof local.projectId === 'string') {
     if (!remoteReadable || remote === null || typeof remote.projectId !== 'string' || remote.projectId !== local.projectId) {
-      return { ok: false, message: `远端记忆身份缺失或不匹配（本地项目 ${local.projectId}）。疑似远端分支被篡改或接错——已拒绝合并。请检查后重试` }
+      return { ok: false, message: swt('syncw.identityMismatchMerge', { local: local.projectId }) }
     }
     return { ok: true }
   }
@@ -615,24 +619,24 @@ export async function resolveConflict(p) {
 async function resolveConflictInner({ dir, index, choice, fileset = 'project', localBranch = 'main' }) {
   // 侧车按 fileset 独立（Codex 二轮 P0-2）
   const path = join(dir, conflictsFileFor(fileset))
-  if (!existsSync(path)) return { ok: false, message: '没有待处理的冲突' }
+  if (!existsSync(path)) return { ok: false, message: swt('syncw.noConflicts') }
   const text = readFileSync(path, 'utf8')
   const conflicts = parseConflicts(text)
   const target = conflicts.find((c) => c.index === index)
   if (target === undefined) {
-    return { ok: false, message: `冲突编号 ${index} 不存在（当前 1..${conflicts.length}）` }
+    return { ok: false, message: swt('syncw.badConflictIndex', { index, max: conflicts.length }) }
   }
   if (!['ours', 'theirs', 'both'].includes(choice)) {
-    return { ok: false, message: '用法：conflict resolve <编号> ours | theirs | both' }
+    return { ok: false, message: swt('syncw.resolveUsage') }
   }
   if (choice !== 'both' && target[choice] === null) {
-    return { ok: false, message: `冲突 ${index} 没有可用的 ${choice} 版本（该侧为空/删除）` }
+    return { ok: false, message: swt('syncw.choiceUnavailable', { index, choice }) }
   }
   // 侧车路径白名单校验（Grok P2-5）：侧车的 file 字段只能指向本 fileset
   // 的同步记忆文件（Codex 二轮 P0-2：按 fileset 校验）——防手工/异常侧车
   // 写穿到任意路径
   if (!isMemoryFile(target.file, fileset)) {
-    return { ok: false, message: `冲突 ${index} 的目标文件不在同步白名单内（${target.file}）——已拒绝写入` }
+    return { ok: false, message: swt('syncw.fileNotWhitelisted', { index, file: target.file }) }
   }
 
   return asyncWithLock(dir, async () => {
@@ -681,15 +685,15 @@ async function resolveConflictInner({ dir, index, choice, fileset = 'project', l
     //    必须如实报错，绝不假报"已解决并提交"。CONFLICTS.md 排除在提交树
     //    外（P0-6：侧车提交后才删，不能留下幽灵文件）**
     const treeResult = await buildFilesetTree(dir, fileset, ['CONFLICTS.md'])
-    if (!treeResult.ok) return { ok: false, message: `解决冲突时 ${treeResult.error}（目标条目已写回，可重试）` }
+    if (!treeResult.ok) return { ok: false, message: swt('syncw.treeStepFail', { error: treeResult.error }) }
     const lb = `refs/heads/${localBranch}`
     const headRef = await runGit(dir, ['rev-parse', '--verify', lb])
     const parents = headRef.ok ? ['-p', lb] : []
     const stamp = new Date().toISOString().slice(0, 19).replace('T', ' ')
     const commit = await runGit(dir, ['commit-tree', ...parents, '-m', `memory: resolve conflict #${index} (${choice}) ${stamp}`, treeResult.tree])
-    if (!commit.ok) return { ok: false, message: `解决冲突时 commit-tree 失败：${commit.stderr.trim().split('\n')[0] ?? ''}（目标条目已写回且写回幂等，可直接重试）` }
+    if (!commit.ok) return { ok: false, message: swt('syncw.commitTreeFail', { detail: commit.stderr.trim().split('\n')[0] ?? '' }) }
     const upd = await runGit(dir, ['update-ref', lb, commit.stdout.trim()])
-    if (!upd.ok) return { ok: false, message: `解决冲突时 update-ref 失败：${upd.stderr.trim().split('\n')[0] ?? ''}。提交已生成但 ref 未更新——侧车仍在，写回幂等，请重试` }
+    if (!upd.ok) return { ok: false, message: swt('syncw.updateRefFail', { detail: upd.stderr.trim().split('\n')[0] ?? '' }) }
 
     // ── 3. 提交成功后才移除侧车条目（稳定版复审 P0-6）：git 失败时侧车
     //    保留（重试继续有冲突可解）；清空则删文件（原子写，Kimi P2-3）──
@@ -706,7 +710,7 @@ async function resolveConflictInner({ dir, index, choice, fileset = 'project', l
     // ── 4. 共享 index 重置到新提交树（单轨项目仓库 git status 恢复干净）──
     // reset 失败不影响已提交结果（ref 已更新），下次同步会自然对齐
     await runGit(dir, ['reset', '-q', lb])
-    return { ok: true, message: `已解决冲突 #${index}（${choice}）并提交`, remaining: remaining.length }
+    return { ok: true, message: swt('syncw.resolved', { index, choice }), remaining: remaining.length }
   })
 }
 

--- a/lib/todo.js
+++ b/lib/todo.js
@@ -32,10 +32,12 @@
  */
 
 import { randomBytes } from 'node:crypto'
-import { translate, TODO_DICT } from './i18n.js'
+import { translate, getLocale, TODO_DICT, TODO_MSG_DICT } from './i18n.js'
 
 /** Translate through the TODO_DICT dictionary in the active locale. */
 const tt = (key, params) => translate(TODO_DICT, key, params)
+/** Translate through TODO_MSG_DICT in the active host locale. */
+const tmt = (key, params) => translate(TODO_MSG_DICT, key, params, getLocale())
 import { mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { ENTRY_DELIMITER, projectHash, scanThreat, serializeEntries, todayStamp, withLock } from './store.js'
@@ -281,7 +283,7 @@ export class TodoStore {
    */
   addTodo(target, content, meta = {}, cwd) {
     const text = String(content ?? '').trim()
-    if (!text) return { ok: false, message: '待办内容不能为空', target }
+    if (!text) return { ok: false, message: tmt('todomsg.emptyContent'), target }
     const threat = scanThreat(text)
     if (threat) return { ok: false, message: threat, target }
     const id = newId()
@@ -300,7 +302,7 @@ export class TodoStore {
       const items = this.itemsOf(target, cwd)
       items.push(item)
       this.write(target, cwd, items)
-      return { ok: true, message: `已添加待办（${target}：${items.length} 条）`, id, target }
+      return { ok: true, message: tmt('todomsg.added', { target, count: items.length }), id, target }
     })
   }
 
@@ -338,7 +340,7 @@ export class TodoStore {
   updateTodo(target, id, patch = {}, cwd, date) {
     const found = this.findById(target, id, cwd, date)
     if (found === null) {
-      return { ok: false, message: `没有找到 id 为 "${id}" 的待办${target ? `（${target} 轨）` : ''}`, target: target ?? '?' }
+      return { ok: false, message: target ? tmt('todomsg.notFoundTrack', { id, target }) : tmt('todomsg.notFound', { id }), target: target ?? '?' }
     }
     const { target: t, item, day } = found
     const meta = parseTodoEntry(item.raw)
@@ -356,11 +358,11 @@ export class TodoStore {
     return withLock(dirname(this.fileOf(t, cwd, day)), () => {
       const current = this.itemsOf(t, cwd, day)
       const index = current.findIndex((entry) => entry.id === id)
-      if (index === -1) return { ok: false, message: '该待办已被删除（可能在其他窗口操作）——请刷新后重试', target: t }
+      if (index === -1) return { ok: false, message: tmt('todomsg.gone'), target: t }
       const next = [...current]
       next[index] = { raw }
       this.write(t, cwd, next, day)
-      return { ok: true, message: `已更新待办（${t}）`, target: t }
+      return { ok: true, message: tmt('todomsg.updated', { target: t }), target: t }
     })
   }
 
@@ -373,17 +375,17 @@ export class TodoStore {
   removeTodo(target, id, cwd, date) {
     const found = this.findById(target, id, cwd, date)
     if (found === null) {
-      return { ok: false, message: `没有找到 id 为 "${id}" 的待办`, target: target ?? '?' }
+      return { ok: false, message: tmt('todomsg.notFound', { id }), target: target ?? '?' }
     }
     const { target: t, day } = found
     return withLock(dirname(this.fileOf(t, cwd, day)), () => {
       const current = this.itemsOf(t, cwd, day)
       const next = current.filter((entry) => entry.id !== id)
       if (next.length === current.length) {
-        return { ok: false, message: '该待办已被删除（可能在其他窗口操作）——请刷新后重试', target: t }
+        return { ok: false, message: tmt('todomsg.gone'), target: t }
       }
       this.write(t, cwd, next, day)
-      return { ok: true, message: `已删除待办（${t}）`, target: t }
+      return { ok: true, message: tmt('todomsg.deleted', { target: t }), target: t }
     })
   }
 
@@ -622,7 +624,7 @@ export function todoToolDefinition(config, todoStore) {
       if (action === 'add') {
         const target = args.target ?? (cwd ? 'project' : 'work')
         if (!TODO_TARGETS.includes(target)) {
-          return { ok: false, message: `无效 target "${target}"（应为 ${TODO_TARGETS.join('/')}）`, target }
+          return { ok: false, message: tmt('todomsg.invalidTarget', { target, valid: TODO_TARGETS.join('/') }), target }
         }
         const due = typeof args.due === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(args.due) ? args.due : undefined
         const cat = typeof args.cat === 'string' && args.cat.trim() !== '' ? args.cat.trim() : undefined
@@ -666,7 +668,7 @@ export function todoToolDefinition(config, todoStore) {
         const outcome = todoStore.updateTodo(args.target, String(args.id ?? ''), patch, cwd, dateArg(args.date))
         return { ok: outcome.ok, message: outcome.message, target: outcome.target }
       }
-      return { ok: false, message: `未知 action "${action}"` }
+      return { ok: false, message: tmt('todomsg.unknownAction', { action }) }
     },
   }
 }

--- a/lib/todo.js
+++ b/lib/todo.js
@@ -32,6 +32,10 @@
  */
 
 import { randomBytes } from 'node:crypto'
+import { translate, TODO_DICT } from './i18n.js'
+
+/** Translate through the TODO_DICT dictionary in the active locale. */
+const tt = (key, params) => translate(TODO_DICT, key, params)
 import { mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { ENTRY_DELIMITER, projectHash, scanThreat, serializeEntries, todayStamp, withLock } from './store.js'
@@ -567,33 +571,33 @@ function resolveQuadrant(args) {
 export function todoToolDefinition(config, todoStore) {
   return {
     name: config.todoToolName,
-    description: '待办管理（四轨：life 生活 / work 工作 / project 项目（按工作目录隔离）/ daily 每日）。用户口述"记住/我要做 X"时用 add 直写——**add 的 target 遵循用户说的类别**（"工作上的事"→work、"生活中的"→life、"这个项目要"→project、"今天要"→daily），用户没说才用缺省（有工作目录 project，无 cwd 用 work）。**list 默认智能视图**：只返回需要关注的未完成项（逾期/今日到期/当前项目/重要紧急，最多 8 条），看全部需显式 all=true 或筛选参数。**查过往（昨天及更早的每日待办）请一次到位：list 加 past=true 且 expired=true**——每日待办截止=当天，过往的每日待办几乎必然已过期（除非已完成），只带 past=true 会隐藏未完成的过期遗留（只能看到已完成的过往）；带齐两个参数才能看到"昨天有哪些待办、哪些没做完"。**跨项目查询**：在别的会话里查某项目的待办用 list 加 target=project 与 cwd=<该项目工作目录路径>。done/update/remove 按 id 精确操作（list 输出带 id；每日过往条目的 id 同样可操作）。模型自建待办请用 memory_suggest target=todo-*（进待确认队列），不要直接 add。',
+    get description() { return tt('todo.desc') },
     parameters: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
           enum: ['add', 'list', 'done', 'update', 'remove'],
-          description: 'add=新增；list=查看（默认智能视图）；done=完成；update=修改；remove=删除',
+          get description() { return tt('todo.action') },
         },
         target: {
           type: 'string',
           enum: TODO_TARGETS,
-          description: 'add：遵循用户说的类别（工作→work、生活→life、项目→project、每日→daily），没说才缺省（有工作目录用 project，否则 work）；list 缺省=综合四轨；done/update/remove 缺省=全轨按 id 查找',
+          get description() { return tt('todo.target') },
         },
-        content: { type: 'string', description: 'add 时必填：待办内容（首行是标题，可多行写详情）；update 时=替换内容' },
-        important: { type: 'boolean', description: '是否重要（与 urgent 组合成四象限）' },
-        urgent: { type: 'boolean', description: '是否紧急' },
-        quadrant: { type: 'string', enum: ['q1', 'q2', 'q3', 'q4'], description: '直接指定四象限（优先于 important/urgent）：q1 重要紧急 / q2 重要不紧急 / q3 紧急不重要 / q4 不重要不紧急' },
-        due: { type: 'string', description: '截止日期 YYYY-MM-DD' },
-        cat: { type: 'string', description: '分类（生活/工作/学习…）' },
-        status: { type: 'string', enum: TODO_STATUSES, description: 'list 筛选（缺省=智能视图）；update 设置新状态' },
-        id: { type: 'string', description: '条目标识（list 返回，如 a1b2c3d4）；done/update/remove 必填' },
-        date: { type: 'string', description: 'daily 轨指定日期 YYYY-MM-DD（缺省=今天）' },
-        all: { type: 'boolean', description: 'list 时 true=显示全部未过滤（默认智能视图）' },
-        past: { type: 'boolean', description: 'list 时 true=同时查询每日待办的过往（昨天及更早的历史条目，带日期）；**查过往请同时带 expired=true**（每日待办截止=当天，未完成的过往必然已过期，默认被隐藏）' },
-        expired: { type: 'boolean', description: 'list 时 true=过往中同时包含已过期的遗留条目（仅与 past=true 配合生效；缺省隐藏已过期且无未来截止的遗留）' },
-        cwd: { type: 'string', description: 'list 时指定项目工作目录路径（跨项目查询：在别的会话里查该项目 target=project 的待办，project 轨按此路径定位；缺省=当前会话工作目录）' },
+        get description() { return tt('todo.content') },
+        get description() { return tt('todo.important') },
+        get description() { return tt('todo.urgent') },
+        get description() { return tt('todo.quadrant') },
+        get description() { return tt('todo.due') },
+        get description() { return tt('todo.cat') },
+        get description() { return tt('todo.status') },
+        get description() { return tt('todo.id') },
+        get description() { return tt('todo.date') },
+        get description() { return tt('todo.all') },
+        get description() { return tt('todo.past') },
+        get description() { return tt('todo.expired') },
+        get description() { return tt('todo.cwd') },
       },
       required: ['action'],
     },

--- a/lib/update.js
+++ b/lib/update.js
@@ -41,6 +41,10 @@
 import { execFile, spawnSync } from 'node:child_process'
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync, realpathSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { translate, getLocale, MISC2_DICT } from './i18n.js'
+
+/** Translate through MISC2_DICT in the active host locale. */
+const upt = (key, params) => translate(MISC2_DICT, key, params, getLocale())
 import { fileURLToPath } from 'node:url'
 import { randomBytes } from 'node:crypto'
 import { promisify } from 'node:util'
@@ -524,7 +528,7 @@ export function createUpdateChecker(opts = {}) {
       await saveCache({
         status: 'unsupported',
         lastAttemptAt: attemptAt,
-        lastError: { kind: 'unsupported', message: '插件目录不是 git 仓库或 git 不可用（请用 git clone 安装）' },
+        lastError: { kind: 'unsupported', message: upt('upd.notGitRepo') },
         noteCode: 'unsupported',
       })
       return { ok: false, state: { ...prev, status: 'unsupported' } }
@@ -532,8 +536,8 @@ export function createUpdateChecker(opts = {}) {
 
     const ls = await runGit(repoDir, ['ls-remote', '--tags', 'origin'], { run })
     if (!ls.ok) {
-      await saveCache({ lastAttemptAt: attemptAt, lastError: { kind: ls.kind, message: `远端检测失败（${ls.kind}）` } })
-      return { ok: false, state: { ...prev, lastAttemptAt: attemptAt, lastError: { kind: ls.kind, message: `远端检测失败（${ls.kind}）` } } }
+      await saveCache({ lastAttemptAt: attemptAt, lastError: { kind: ls.kind, message: upt('upd.remoteCheckFailed', { kind: ls.kind }) } })
+      return { ok: false, state: { ...prev, lastAttemptAt: attemptAt, lastError: { kind: ls.kind, message: upt('upd.remoteCheckFailed', { kind: ls.kind }) } } }
     }
     const tags = parseTagRefs(ls.stdout)
     const latest = tags.length > 0 ? tags[tags.length - 1] : null

--- a/scripts/sync-worker.mjs
+++ b/scripts/sync-worker.mjs
@@ -18,6 +18,10 @@
  */
 
 import { runStatus, runSync } from '../lib/sync/worker.js'
+import { setLocale, resolveLocale } from '../lib/i18n.js'
+
+// Inherit the spawning host's language (spawnWorker passes DSH_LOCALE).
+setLocale(resolveLocale(undefined))
 import { decideModeBBranch, ensureGlobalRepo } from '../lib/sync/repo.js'
 
 const [, , sub, dir, arg3, ...rest] = process.argv

--- a/src/client/BroadcastView.tsx
+++ b/src/client/BroadcastView.tsx
@@ -69,7 +69,7 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
 
 function errText(err: unknown): string {
   const text = err instanceof Error ? err.message : String(err)
-  return text !== undefined && text.trim() !== '' ? text : '操作失败（无错误详情）'
+  return text !== undefined && text.trim() !== '' ? text : (isEn() ? 'Operation failed (no error detail)' : '操作失败（无错误详情）')
 }
 
 function fmtTime(ts: number): string {
@@ -197,6 +197,9 @@ function WsCoordSettings({ t }: { t: Translate }): JSX.Element {
     </div>
   )
 }
+
+/** English browser → English inline text. */
+const isEn = (): boolean => typeof navigator !== 'undefined' && navigator.language?.toLowerCase().startsWith('en')
 
 export function BroadcastView(props: ConvViewProps & { t: Translate }): JSX.Element {
   const { t, sessionId } = props
@@ -385,7 +388,7 @@ export function BroadcastView(props: ConvViewProps & { t: Translate }): JSX.Elem
     try {
       const res = await fetchJson<{ ok: boolean; message?: string }>(`/rooms/${encodeURIComponent(room.id)}/dissolve`, { method: 'POST' })
       if (res.ok !== true) {
-        setNotice({ kind: 'error', text: res.message ?? '操作失败' })
+        setNotice({ kind: 'error', text: res.message ?? (isEn() ? 'Operation failed' : '操作失败') })
         return
       }
       setNotice({ kind: 'ok', text: t('broadcast.room.dissolved') })
@@ -404,14 +407,14 @@ export function BroadcastView(props: ConvViewProps & { t: Translate }): JSX.Elem
 
   /** 消息卡片（消息列表与房间消息共用）。 */
   const renderMsgCard = (m: Msg, expandId: string, setExpandId: (id: string | null) => void): JSX.Element => {
-    const from = m.sender === 'system' ? '系统' : displayName(m.sender, aliases)
+    const from = m.sender === 'system' ? (isEn() ? 'System' : '系统') : displayName(m.sender, aliases)
     const to = m.recipients.map((r) => recipientLabel(r, roomMap, aliases)).join(', ')
     const unread = m.readBy.length === 0 // 超管视角：无人读过 = 未读
     const isOpen = expandId === m.id
     return (
       <div key={m.id} className="bb-card">
         <div className="bb-row">
-          <span className="bb-strong">{m.subject || '（无主题）'}</span>
+          <span className="bb-strong">{m.subject || (isEn() ? '(no subject)' : '（无主题）')}</span>
           <span className={`bb-badge${unread ? ' bb-badge-unread' : ' bb-badge-read'}`}>
             {unread ? t('broadcast.msg.unread') : t('broadcast.msg.read')}
           </span>

--- a/src/client/CoIView.tsx
+++ b/src/client/CoIView.tsx
@@ -475,8 +475,8 @@ const DICT = {
 
 type DictKey = keyof (typeof DICT)['zh']
 
-/** 当前语言（默认中文；无切换 UI）。 */
-const LANG: keyof typeof DICT = 'zh'
+/** 当前语言：浏览器为英文时用 en，否则 zh（与 PromptView 同规则）。 */
+const LANG: keyof typeof DICT = (typeof navigator !== 'undefined' && navigator.language?.toLowerCase().startsWith('en')) ? 'en' : 'zh'
 
 /** 字典查询：当前语言 → en 兜底 → key 本身。 */
 function t(key: DictKey): string {

--- a/src/client/MemoryQueueView.tsx
+++ b/src/client/MemoryQueueView.tsx
@@ -26,10 +26,10 @@ export interface MemoryQueueViewProps {
 /** 待办建议 target 的展示名（todo-life → 待办·生活）。 */
 function todoTargetLabel(t: Translate, target: string): string {
   const track = target.slice(5)
-  if (track === 'life') return `待办·${t('todo.track.life')}`
-  if (track === 'work') return `待办·${t('todo.track.work')}`
-  if (track === 'project') return `待办·${t('todo.track.project')}`
-  if (track === 'daily') return `待办·${t('todo.track.daily')}`
+  if (track === 'life') return `${isEn() ? 'Todo' : '待办'}·${t('todo.track.life')}`
+  if (track === 'work') return `${isEn() ? 'Todo' : '待办'}·${t('todo.track.work')}`
+  if (track === 'project') return `${isEn() ? 'Todo' : '待办'}·${t('todo.track.project')}`
+  if (track === 'daily') return `${isEn() ? 'Todo' : '待办'}·${t('todo.track.daily')}`
   return target
 }
 
@@ -145,8 +145,8 @@ async function api<T>(path: string, init?: RequestInit): Promise<T> {
 
 /** Summarize an approve/reject report into one line. */
 function summarizeReport(report: { lines?: string[]; removed?: number; remaining: number }): string {
-  const head = report.lines?.join('；') ?? `已处理 ${report.removed ?? 0} 条`
-  return `${head}（剩余 ${report.remaining} 条）`
+  const head = report.lines?.join(isEn() ? '; ' : '；') ?? (isEn() ? `${report.removed ?? 0} handled` : `已处理 ${report.removed ?? 0} 条`)
+  return isEn() ? `${head} (${report.remaining} remaining)` : `${head}（剩余 ${report.remaining} 条）`
 }
 
 /** Display-side formatting of the ISO timestamp; falls back to the raw string. */
@@ -157,6 +157,9 @@ function formatTime(iso: string): string {
 }
 
 /** The three feature panels (suggestions / skills / config). */
+/** English browser → English inline text. */
+const isEn = (): boolean => typeof navigator !== 'undefined' && navigator.language?.toLowerCase().startsWith('en')
+
 export function MemoryQueueView(props: MemoryQueueViewProps): JSX.Element {
   const { t, feature, onChanged } = props
   const [entries, setEntries] = useState<SuggestionRow[] | null>(null)

--- a/src/client/SyncView.tsx
+++ b/src/client/SyncView.tsx
@@ -97,7 +97,9 @@ async function api<T>(path: string, init?: RequestInit): Promise<T> {
 
 /** 截断长文本（冲突三方片段展示用）。 */
 function clamp(text: string | null, max = 60): string {
-  if (text === null) return '（无）'
+  if (text === null) {
+    return typeof navigator !== 'undefined' && navigator.language?.toLowerCase().startsWith('en') ? '(none)' : '（无）'
+  }
   const flat = text.replace(/\s+/g, ' ')
   return flat.length > max ? `${flat.slice(0, max)}…` : flat
 }

--- a/src/client/TodoView.tsx
+++ b/src/client/TodoView.tsx
@@ -132,7 +132,9 @@ function statusLabel(t: Translate, status: string): string {
 /** 'YYYY-MM-DD' → '8月5日'（过往分组标题）。 */
 function dayLabel(day: string): string {
   const [, month, date] = day.split('-')
-  return `${Number(month)}月${Number(date)}日`
+  return typeof navigator !== 'undefined' && navigator.language?.toLowerCase().startsWith('en')
+      ? `${Number(month)}/${Number(date)}`
+      : `${Number(month)}月${Number(date)}日`
 }
 
 /**

--- a/src/client/advisor/AdvisorPanel.tsx
+++ b/src/client/advisor/AdvisorPanel.tsx
@@ -54,25 +54,31 @@ interface CapsuleDragState {
   dragged: boolean
 }
 
+/** English browser → English panel labels; anything else keeps Chinese. */
+const isEn = (): boolean => typeof navigator !== 'undefined' && navigator.language?.toLowerCase().startsWith('en')
+
 const STATUS_META: Record<AdvisorRuntimeStatus, { icon: string; label: string; cls: string }> = {
-  disabled: { icon: '✖', label: '已停用', cls: 'advisor-status-disabled' },
-  idle: { icon: '●', label: '空闲', cls: 'advisor-status-idle' },
-  reviewing: { icon: '◐', label: '评审中', cls: 'advisor-status-reviewing' },
-  quota_exhausted: { icon: '⏸', label: '已暂停', cls: 'advisor-status-paused' },
-  halted: { icon: '⚠', label: '已终止', cls: 'advisor-status-halted' },
+  get disabled() { return { icon: '✖', label: isEn() ? 'Disabled' : '已停用', cls: 'advisor-status-disabled' } },
+  get idle() { return { icon: '●', label: isEn() ? 'Idle' : '空闲', cls: 'advisor-status-idle' } },
+  get reviewing() { return { icon: '◐', label: isEn() ? 'Reviewing' : '评审中', cls: 'advisor-status-reviewing' } },
+  get quota_exhausted() { return { icon: '⏸', label: isEn() ? 'Paused' : '已暂停', cls: 'advisor-status-paused' } },
+  get halted() { return { icon: '⚠', label: isEn() ? 'Halted' : '已终止', cls: 'advisor-status-halted' } },
 }
 
 const SEVERITY_META: Record<AdvisorNoteSeverity, { label: string; cls: string }> = {
   // Q1：info 最低等级（默认仅记录不注入，面板照常展示）
-  info: { label: 'info · 记录', cls: 'advisor-severity-info' },
-  nit: { label: 'nit · 建议', cls: 'advisor-severity-nit' },
-  concern: { label: 'concern · 关注', cls: 'advisor-severity-concern' },
-  blocker: { label: 'blocker · 阻断', cls: 'advisor-severity-blocker' },
+  info: { get label() { return isEn() ? 'info · note' : 'info · 记录' }, cls: 'advisor-severity-info' },
+  nit: { get label() { return isEn() ? 'nit · suggestion' : 'nit · 建议' }, cls: 'advisor-severity-nit' },
+  concern: { get label() { return isEn() ? 'concern · watch' : 'concern · 关注' }, cls: 'advisor-severity-concern' },
+  blocker: { get label() { return isEn() ? 'blocker · blocking' : 'blocker · 阻断' }, cls: 'advisor-severity-blocker' },
   // Q4：问答回复（用户提问的直接回答，非评审建议）
-  answer: { label: '回答', cls: 'advisor-severity-answer' },
+  answer: { get label() { return isEn() ? 'answer' : '回答' }, cls: 'advisor-severity-answer' },
 }
 
-const OUTCOME_LABEL = {
+function outcomeLabel(outcome: keyof typeof OUTCOME_ZH): string {
+  return isEn() ? OUTCOME_EN[outcome] : OUTCOME_ZH[outcome]
+}
+const OUTCOME_ZH = {
   delivered: '已送达',
   // Q1：info 级默认仅记录（事件照发、面板可见，会话流不受打扰）
   recorded: '已记录',
@@ -83,6 +89,16 @@ const OUTCOME_LABEL = {
   dropped: '已丢弃',
   failed: '评审失败',
   cancelled: '已取消',
+} as const
+const OUTCOME_EN = {
+  delivered: 'Delivered',
+  recorded: 'Recorded',
+  answered: 'Answered',
+  suppressed: 'Suppressed',
+  'no-note': 'No note',
+  dropped: 'Dropped',
+  failed: 'Review failed',
+  cancelled: 'Cancelled',
 } as const
 
 function pad2(value: number): string {
@@ -827,7 +843,7 @@ function ReviewCard(props: {
         {terminal !== null && <span>{formatElapsed(terminal.elapsedMs)}</span>}
         {terminal?.delivery === 'steer' && <span className="advisor-delivery">已送达 ✓</span>}
         {terminal?.delivery === 'inject' && <span className="advisor-delivery">已注入 ✓</span>}
-        {terminal !== null && terminal.delivery === null && <span>{OUTCOME_LABEL[terminal.outcome]}</span>}
+        {terminal !== null && terminal.delivery === null && <span>{outcomeLabel(terminal.outcome)}</span>}
       </div>
 
       {identity !== null && <div className="advisor-record-owner" title={identity}>{identity}</div>}
@@ -877,7 +893,7 @@ function ReviewCard(props: {
           {note.text}
         </div>
       ) : (
-        <div className="advisor-outcome-empty">{OUTCOME_LABEL[terminal.outcome]}</div>
+        <div className="advisor-outcome-empty">{outcomeLabel(terminal.outcome)}</div>
       )}
 
       {terminal?.error !== null && terminal?.error !== undefined && (

--- a/src/client/notification-bell.tsx
+++ b/src/client/notification-bell.tsx
@@ -195,7 +195,7 @@ function writeDock(dock: BellDock): void {
 /* ------------------------------------------------------------------ */
 
 /** 邮件字段行：📮 主题：xxx / 📝 简介：xxx / 📄 内容（值可空，正文在后续行）。 */
-const MAIL_FIELD_RE = /^(📮|📝|👤|🕐|📄)\s*(主题|简介|发送人|时间|内容)\s*[：:]?\s*(.*)$/
+const MAIL_FIELD_RE = /^(📮|📝|👤|🕐|📄)\s*(主题|简介|发送人|时间|内容|Subject|Intro|Sender|Time|Content)\s*[：:]?\s*(.*)$/
 /** 纯装饰分隔线（━ / ─ / — / - / = 重复），展示时丢掉。 */
 const SEP_RE = /^[━─—\-_=]{4,}\s*$/
 
@@ -209,7 +209,7 @@ function collapseBlank(text: string): string {
 
 /** 去掉「📮 主题：」这类字段前缀，避免主题栏再显示一遍「主题」。 */
 function stripSubjectPrefix(s: string): string {
-  return String(s ?? '').replace(/^[📮📝👤🕐📄]\s*(主题|简介|发送人|时间|内容)\s*[：:]\s*/, '').trim()
+  return String(s ?? '').replace(/^[📮📝👤🕐📄]\s*(主题|简介|发送人|时间|内容|Subject|Intro|Sender|Time|Content)\s*[：:]\s*/, '').trim()
 }
 
 /**
@@ -244,11 +244,11 @@ function parseNotifyContent(raw: string): MailFields {
       result.mail = true
       const key = m[2]
       const val = (m[3] ?? '').trim()
-      if (key === '主题') result.subject = val
-      else if (key === '简介') result.intro = val
-      else if (key === '发送人') result.sender = val
-      else if (key === '时间') result.time = val
-      else if (key === '内容') {
+      if (key === '主题' || key === 'Subject') result.subject = val
+      else if (key === '简介' || key === 'Intro') result.intro = val
+      else if (key === '发送人' || key === 'Sender') result.sender = val
+      else if (key === '时间' || key === 'Time') result.time = val
+      else if (key === '内容' || key === 'Content') {
         inBody = true
         if (val) bodyLines.push(val)
       }

--- a/tests/advisor-commands.test.js
+++ b/tests/advisor-commands.test.js
@@ -6,6 +6,10 @@ import { join } from 'node:path'
 import { installAdvisor } from '../lib/advisor/index.js'
 import { validateRuntimePatch } from '../lib/index.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** 最小 cordis ctx（commands 注册捕获）。 */
 function makeCtx() {
   const listeners = {}

--- a/tests/advisor-observer.test.js
+++ b/tests/advisor-observer.test.js
@@ -9,6 +9,10 @@ import {
 } from '../lib/advisor/observer.js'
 import { ADVISOR_SOURCE_KIND } from '../lib/advisor/kinds.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 // ---------------------------------------------------------------------------
 // 事件与消息构造
 // ---------------------------------------------------------------------------

--- a/tests/advisor-optin.test.js
+++ b/tests/advisor-optin.test.js
@@ -13,6 +13,10 @@ import { join } from 'node:path'
 import { installAdvisor } from '../lib/advisor/index.js'
 import { validateRuntimePatch } from '../lib/index.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 let seq = 0
 const nextSeq = () => seq++
 

--- a/tests/advisor-runtime.test.js
+++ b/tests/advisor-runtime.test.js
@@ -2,6 +2,10 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { AdvisorRuntime, extractAdviceNote, ADVISOR_NOTE_MAX_CHARS } from '../lib/advisor/runtime.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** 静默 logger（测试不刷屏）。 */
 const silent = { debug() {}, warn() {} }
 

--- a/tests/advisor-store.test.js
+++ b/tests/advisor-store.test.js
@@ -7,6 +7,10 @@ import { appendFile } from 'node:fs/promises'
 import { InstructionQueue, INSTRUCTION_MAX_CHARS, PENDING_MAX } from '../lib/advisor/instructions.js'
 import { ReviewStore, RING_CAPACITY, RECORDS_MAX_LIMIT } from '../lib/advisor/store.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function tempDir(tag) {
   return mkdtempSync(join(tmpdir(), `dsh-advisor-${tag}-`))
 }

--- a/tests/aliases.test.js
+++ b/tests/aliases.test.js
@@ -11,6 +11,10 @@ import { AliasStore, readAliases } from '../lib/aliases.js'
 import { resolveConfig, renderSnapshot } from '../lib/index.js'
 import { MemoryStore } from '../lib/store.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function tempDir() {
   return mkdtempSync(join(tmpdir(), 'dsh-alias-test-'))
 }

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -9,6 +9,10 @@ import { installApi } from '../lib/api.js'
 import { validateRuntimePatch } from '../lib/index.js'
 import { TodoStore } from '../lib/todo.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function tempDir() {
   return mkdtempSync(join(tmpdir(), 'dsh-memory-api-test-'))
 }

--- a/tests/broadcast-image.test.js
+++ b/tests/broadcast-image.test.js
@@ -26,6 +26,10 @@ import {
 } from '../lib/coi/broadcast.js'
 import { resolveConfig, validateRuntimePatch, RUNTIME_KEYS } from '../lib/index.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** 1x1 透明 PNG 的 base64（真实可解码的最小 PNG）。 */
 const PNG_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
 

--- a/tests/canvas.test.js
+++ b/tests/canvas.test.js
@@ -31,6 +31,10 @@ import {
   writeCanvas,
 } from '../lib/canvas.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /**
  * 每个测试独立临时目录；测试后统一清理（不留 /tmp/canvas-test-* 垃圾）。
  * 目录不清理曾导致 /tmp 堆积，且「真实打开」测试弹出的文件管理器窗口在

--- a/tests/coi-attachments.test.js
+++ b/tests/coi-attachments.test.js
@@ -27,6 +27,10 @@ import { TemplateStore } from '../lib/coi/templates.js'
 import { CoiScheduler } from '../lib/coi/scheduler.js'
 import { resolveAttachments } from '../lib/coi/attachments.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** 所有测试创建的调度器：统一 dispose，避免 flush 定时器挂住事件循环。 */
 const schedulers = []
 after(() => {

--- a/tests/coi-templates-i18n.test.js
+++ b/tests/coi-templates-i18n.test.js
@@ -1,0 +1,54 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { TemplateStore, BUILTIN_TEMPLATES } from '../lib/coi/templates.js'
+import { setLocale, getLocale, translate, COI_DICT } from '../lib/i18n.js'
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), 'dsh-coi-tpl-i18n-'))
+}
+
+test('builtin template display names follow the active locale', () => {
+  const dir = tempDir()
+  const prevLocale = getLocale()
+  try {
+    const templates = new TemplateStore(join(dir, 'templates.json'))
+    for (const locale of ['en', 'zh']) {
+      setLocale(locale)
+      const list = templates.list()
+      assert.equal(list.length, BUILTIN_TEMPLATES.length)
+      for (const tpl of list) {
+        const expected = translate(COI_DICT, `coi.template.name.${tpl.id}`, undefined, locale)
+        assert.equal(
+          typeof expected, 'string',
+          `[${locale}] dict must carry a name for builtin ${tpl.id}`,
+        )
+        assert.equal(
+          tpl.name, expected,
+          `[${locale}] builtin template ${tpl.id} must localize`,
+        )
+      }
+    }
+  } finally {
+    setLocale(prevLocale)
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('custom template names are stored verbatim in every locale', () => {
+  const dir = tempDir()
+  const prevLocale = getLocale()
+  try {
+    const templates = new TemplateStore(join(dir, 'templates.json'))
+    setLocale('en')
+    const custom = templates.upsert({ id: 'my-tpl', name: '我的模板', prompt: 'do x' })
+    assert.equal(custom.name, '我的模板')
+    setLocale('zh')
+    assert.equal(templates.get('my-tpl').name, '我的模板')
+  } finally {
+    setLocale(prevLocale)
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/tests/coi.test.js
+++ b/tests/coi.test.js
@@ -20,6 +20,10 @@ import { validateCoiRuntimePatch } from '../lib/coi/index.js'
 import { buildMemoryContext, resolveConfig, renderSnapshot } from '../lib/index.js'
 import { MemoryStore } from '../lib/store.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** 所有测试创建的调度器：统一 dispose，避免 flush 定时器挂住事件循环。 */
 const schedulers = []
 after(() => {

--- a/tests/config-freshness.test.js
+++ b/tests/config-freshness.test.js
@@ -36,7 +36,9 @@ function fakeCtx() {
       return { dispose: disposer ?? (() => {}) }
     },
     effect: (fn) => { const disposer = fn(); return disposer ?? (() => {}) },
-    get: (key) => services[key],
+    // This suite pins Chinese snapshot output: expose a zh locale preference
+    // so apply()'s boot-time resolveLocale() resolves to 'zh'.
+    get: (key) => services[key] ?? (key === 'settings' ? { get: (ns) => (ns === 'locale' ? { preference: 'zh' } : undefined) } : undefined),
     logger: { warn: () => {}, info: () => {}, error: () => {} },
   }
   return ctx

--- a/tests/entries-batch-fault.test.js
+++ b/tests/entries-batch-fault.test.js
@@ -6,6 +6,10 @@ import { join } from 'node:path'
 import { MemoryStore } from '../lib/store.js'
 import { memoryTool } from '../lib/index.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function tempDir() {
   return mkdtempSync(join(tmpdir(), 'dsh-mem-evolve-test-'))
 }

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -1,0 +1,230 @@
+/**
+ * English-support i18n tests: dictionary integrity, locale resolution, the
+ * live settings/updated switch, and per-locale output of user-facing
+ * surfaces (tool descriptions, store messages, feedback lines, snapshot).
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  LOCALES,
+  MEMORY_DICT,
+  REVIEW_DICT,
+  TODO_DICT,
+  SKILL_DICT,
+  SNAPSHOT_DICT,
+  STORE_DICT,
+  STORE_TAIL_DICT,
+  REVIEW_CMD_DICT,
+  resolveLocale,
+  setLocale,
+  getLocale,
+  translate,
+} from '../lib/i18n.js'
+import { MemoryStore } from '../lib/store.js'
+import { memoryTool, renderSnapshot, resolveConfig } from '../lib/index.js'
+import { reviewStatusTool, suggestToolDefinition, reviewTurnCounter } from '../lib/review.js'
+import { todoToolDefinition, TodoStore } from '../lib/todo.js'
+import { skillManageTool } from '../lib/skills.js'
+import { SuggestionQueue } from '../lib/store.js'
+
+const ALL_DICTS = [
+  ['MEMORY', MEMORY_DICT],
+  ['REVIEW', REVIEW_DICT],
+  ['TODO', TODO_DICT],
+  ['SKILL', SKILL_DICT],
+  ['SNAPSHOT', SNAPSHOT_DICT],
+  ['STORE', STORE_DICT],
+  ['STORE_TAIL', STORE_TAIL_DICT],
+  ['REVIEW_CMD', REVIEW_CMD_DICT],
+]
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), 'i18n-test-'))
+}
+
+function clean(dir) {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+test('every dictionary key carries a non-empty zh/en pair', () => {
+  for (const [name, dict] of ALL_DICTS) {
+    const keys = Object.keys(dict)
+    assert.ok(keys.length > 0, `${name} dict must not be empty`)
+    for (const [key, pair] of Object.entries(dict)) {
+      assert.ok(Array.isArray(pair), `${name}.${key} must be a [zh, en] array`)
+      assert.equal(pair.length, 2, `${name}.${key} must have exactly two cells`)
+      assert.ok(typeof pair[0] === 'string' && pair[0].length > 0, `${name}.${key} zh cell must be non-empty`)
+      assert.ok(typeof pair[1] === 'string' && pair[1].length > 0, `${name}.{key} en cell must be non-empty`.replace('{key}', key))
+    }
+  }
+})
+
+test('translate substitutes {name} params and falls back to the key when missing', () => {
+  const dict = { 'k.hello': ['Xin chào {name}', 'Hello {name}'] }
+  assert.equal(translate(dict, 'k.hello', { name: 'Kai' }, 'en'), 'Hello Kai')
+  assert.equal(translate(dict, 'k.hello', { name: 'Minh' }, 'zh'), 'Xin chào Minh')
+  assert.equal(translate(dict, 'k.missing'), 'k.missing')
+  // unknown param stays as-is
+  assert.equal(translate(dict, 'k.hello', { other: 1 }, 'en'), 'Hello {name}')
+})
+
+test('resolveLocale: en only when DSH Language preference is explicitly en; legacy default stays zh', async () => {
+  const makeCtx = (section) => ({
+    get: (name) => (name === 'settings' ? { get: (ns) => (ns === 'locale' ? section : undefined) } : undefined),
+  })
+  setLocale('en') // reset singleton to the plugin default
+  assert.deepEqual(LOCALES, ['zh', 'en'])
+  assert.equal(resolveLocale(undefined), 'en', 'no settings service → default en')
+  assert.equal(resolveLocale(makeCtx(undefined)), 'en', 'settings without a locale section → en')
+  assert.equal(resolveLocale(makeCtx({ preference: 'auto' })), 'en', 'auto → en')
+  assert.equal(resolveLocale(makeCtx({ preference: 'zh' })), 'zh', 'explicit zh → zh')
+  assert.equal(resolveLocale(makeCtx({ preference: 'en' })), 'en')
+})
+
+test('setLocale/getLocale round-trip and ignore invalid ids', () => {
+  setLocale('zh')
+  assert.equal(getLocale(), 'zh')
+  setLocale('fr')
+  assert.equal(getLocale(), 'zh', 'invalid ids are ignored')
+  setLocale('en')
+  assert.equal(getLocale(), 'en')
+  setLocale('en') // restore default for later tests
+})
+
+test('memory tool description follows the active locale via getter', async () => {
+  const dir = tempDir()
+  const config = resolveConfig({ memoryDir: dir })
+  const store = new MemoryStore(config.memoryDir, config)
+  const queue = new SuggestionQueue(join(dir, 'suggestions.json'))
+  const tool = memoryTool({}, config, store, queue, () => config, undefined)
+  setLocale('zh')
+  assert.ok(tool.description.startsWith('读写长期记忆'))
+  setLocale('en')
+  assert.ok(tool.description.startsWith('Read/write long-term memory'))
+  setLocale('zh')
+  clean(dir)
+})
+
+/** Fake exec context with an agent whose cwd points at dir (project track). */
+function fakeExec(cwd) {
+  return { agent: cwd ? { id: 'a1', session: { header: { cwd } } } : { id: 'a1' } }
+}
+
+test('store result messages render in both locales', () => {
+  const dir = tempDir()
+  const store = new MemoryStore(dir)
+  setLocale('en')
+  const empty = store.add('memory', '   ')
+  assert.equal(empty.message, 'Content must not be empty')
+  store.add('memory', 'abc')
+  const dup = store.add('memory', 'abc')
+  assert.equal(dup.message, 'Entry already exists; not added again')
+  const added = store.add('memory', 'def')
+  assert.match(added.message, /^Added \(memory: \d+ → \d+ entries\)$/)
+  const noMatch = store.replace('memory', 'zzz-not-there', 'new text')
+  assert.equal(noMatch.message, 'No entry contains the substring "zzz-not-there"')
+  const multi = store.add('memory', 'dup-target')
+  store.add('memory', 'dup-target again')
+  void multi
+  setLocale('zh')
+  const dupZh = store.add('memory', 'abc')
+  assert.equal(dupZh.message, '条目已存在，未重复添加')
+  clean(dir)
+})
+
+test('feedback line renders in both locales', async () => {
+  const dir = tempDir()
+  mkdirSync(dir, { recursive: true })
+  const config = resolveConfig({ memoryDir: dir })
+  const store = new MemoryStore(config.memoryDir, config)
+  const queue = new SuggestionQueue(join(dir, 'suggestions.json'))
+  const projectDir = join(dir, 'proj')
+  mkdirSync(projectDir, { recursive: true })
+  const tool = memoryTool({}, config, store, queue, () => config, undefined)
+  setLocale('en')
+  await tool.execute(
+    { action: 'add', target: 'daily', content: 'shipped the parser', feedback: { sentiment: 'positive', category: 'Coding/Backend', quote: 'great work!', note: 'clean fix' } },
+    fakeExec(),
+  )
+  const daily = readFileSync(join(config.memoryDir, `daily/${new Date().toISOString().slice(0, 10)}.md`), 'utf8')
+  assert.ok(daily.includes('[Feedback]sentiment:positive | category:Coding/Backend | quote:"great work!" | note:clean fix'), daily)
+  setLocale('zh')
+  await tool.execute(
+    { action: 'add', target: 'daily', content: 'hoàn tất parser', feedback: { sentiment: 'negative', category: '编程/后端' } },
+    fakeExec(),
+  )
+  const dailyZh = readFileSync(join(config.memoryDir, `daily/${new Date().toISOString().slice(0, 10)}.md`), 'utf8')
+  assert.ok(dailyZh.includes('【反馈】情绪:负面 | 分类:编程/后端'), dailyZh)
+  clean(dir)
+})
+
+test('renderSnapshot duties follow the active locale (legacy zh assertions keep passing)', () => {
+  const dir = tempDir()
+  const config = resolveConfig({ memoryDir: dir })
+  const store = new MemoryStore(config.memoryDir, config)
+  const agent = { id: 'a', session: { header: { cwd: '/proj/x' } } }
+  store.add('key', 'X 项目的长期约定', agent)
+  setLocale('zh')
+  const zhSnap = renderSnapshot(config, store, agent)
+  assert.ok(zhSnap.includes('## 记忆 memory-evolve'))
+  assert.ok(zhSnap.includes('每轮收尾'))
+  assert.ok(zhSnap.includes('严禁先调工具'))
+  assert.ok(zhSnap.includes('## 本项目关键记忆'))
+  setLocale('en')
+  const enSnap = renderSnapshot(config, store, agent)
+  assert.ok(enSnap.includes('## Memory memory-evolve'), enSnap.slice(0, 400))
+  assert.ok(enSnap.includes('End of every turn'))
+  assert.ok(enSnap.includes('calling tools first is strictly forbidden'))
+  assert.ok(enSnap.includes("This project's key memories"))
+  assert.ok(enSnap.includes('X 项目的长期约定'), 'entry content itself is never translated')
+  assert.ok(!enSnap.includes('每轮收尾'))
+  setLocale('zh')
+  clean(dir)
+})
+
+test('review status + suggest tool descriptions follow the locale', () => {
+  const dir = tempDir()
+  const runtime = { reviewInterval: 20, reviewEnabled: true, reviewMode: 'suggest' }
+  const counter = { turnsOf: () => 0, complete: () => {} }
+  setLocale('en')
+  const rs = reviewStatusTool(() => runtime, counter)
+  assert.ok(rs.description.startsWith('Completes the automatic memory review'))
+  const config = resolveConfig({ memoryDir: dir })
+  const queue = new SuggestionQueue(join(dir, 'suggestions.json'))
+  const sg = suggestToolDefinition(config, queue)
+  assert.ok(sg.description.startsWith('Propose one long-term-memory suggestion'))
+  setLocale('zh')
+  assert.ok(reviewStatusTool(() => runtime, counter).description.startsWith('完成每 N 个用户回合的自动记忆审查'))
+  clean(dir)
+})
+
+test('todo + skill tool descriptions follow the locale', () => {
+  const dir = tempDir()
+  const config = resolveConfig({ memoryDir: dir })
+  const todoStore = new TodoStore(config.memoryDir)
+  setLocale('en')
+  const todo = todoToolDefinition(config, todoStore)
+  assert.ok(todo.description.startsWith('Todo management (four tracks'))
+  const skill = skillManageTool({}, config)
+  assert.ok(skill.description.startsWith('Manage the skill library'))
+  setLocale('zh')
+  assert.ok(todoToolDefinition(config, todoStore).description.startsWith('待办管理（四轨'))
+  clean(dir)
+})
+
+test('skill validation messages follow the locale', async () => {
+  const dir = tempDir()
+  const config = resolveConfig({ memoryDir: dir })
+  const skill = skillManageTool({}, config)
+  setLocale('en')
+  const bad = await skill.execute({ action: 'create', name: 'Bad Name', body: '---\nname: x\n' }, fakeExec())
+  assert.ok(bad.message.includes('Invalid skill name'), bad.message)
+  setLocale('zh')
+  const badZh = await skill.execute({ action: 'create', name: 'Bad Name', body: '---\nname: x\n' }, fakeExec())
+  assert.ok(badZh.message.includes('无效技能名'), badZh.message)
+  clean(dir)
+})

--- a/tests/memory-tab.test.js
+++ b/tests/memory-tab.test.js
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { MemoryStore } from '../lib/store.js'
 import { buildMemoryFiles } from '../lib/memory-tab.js'
+import { setLocale, getLocale } from '../lib/i18n.js'
 
 function tempDir() {
   return mkdtempSync(join(tmpdir(), 'dsh-memory-tab-test-'))
@@ -47,6 +48,38 @@ test('buildMemoryFiles lists all nine tracks with content', () => {
     assert.equal(byKey['archive-key'].available, true)
     assert.equal(byKey['archive-key'].exists, false)
   } finally {
+    process.env.DSH_HOME = prevHome
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('buildMemoryFiles localizes row titles with the active locale', () => {
+  const { dir, config, store } = setup()
+  const prevHome = process.env.DSH_HOME
+  process.env.DSH_HOME = dir
+  const prevLocale = getLocale()
+  try {
+    // English (default): titles must not be the legacy Chinese strings.
+    setLocale('en')
+    let files = buildMemoryFiles(config, store, '/work/p')
+    assert.equal(files.length, 9)
+    const enByTitle = Object.fromEntries(files.map((f) => [f.title, f]))
+    assert.deepEqual(
+      Object.keys(enByTitle).sort(),
+      ['AGENTS.md', 'Archived key facts KEY-archive.md', 'Archived long-term memory MEMORY-archive.md',
+        'Archived user profile USER-archive.md', 'Daily log', 'Key project facts KEY.md',
+        'Long-term memory MEMORY.md', 'Project log', 'User profile USER.md'].sort(),
+    )
+    // Chinese: legacy contract titles stay byte-identical.
+    setLocale('zh')
+    files = buildMemoryFiles(config, store, '/work/p')
+    const zhByTitle = Object.fromEntries(files.map((f) => [f.title, f]))
+    assert.equal(zhByTitle['项目日志'] !== undefined, true)
+    assert.equal(zhByTitle['今日日志'] !== undefined, true)
+    assert.equal(zhByTitle['长期记忆 MEMORY.md'] !== undefined, true)
+    assert.equal(zhByTitle['全局规则 AGENTS.md'] !== undefined, true)
+  } finally {
+    setLocale(prevLocale)
     process.env.DSH_HOME = prevHome
     rmSync(dir, { recursive: true, force: true })
   }

--- a/tests/notify.test.js
+++ b/tests/notify.test.js
@@ -30,6 +30,10 @@ import {
 import { buildNotify, buildChannelContent } from '../lib/coi/index.js'
 import { resolveConfig, validateRuntimePatch, RUNTIME_KEYS } from '../lib/index.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 const REGISTRY_KEY = '__dshChannelNotify'
 
 // 每个用例前后清理注册表，防止测试间相互污染

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -5,7 +5,11 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { apply, gitBranch, gitBranchList, resolveConfig, renderSnapshot, resolveRevealTarget, toWindowsPath } from '../lib/index.js'
+import { setLocale } from '../lib/i18n.js'
 import { installCanvas } from '../lib/canvas.js'
+
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+setLocale('zh')
 import { MemoryStore, projectHash } from '../lib/store.js'
 
 /** Whether `git` is available in this environment (skip git tests otherwise). */
@@ -57,6 +61,9 @@ function fakeCtx(overrides = {}) {
     webServer: { register: (route) => { state.routes.push(route); return () => {} } },
     ...(overrides.services ?? {}),
   }
+  // Locale settings service: this suite pins Chinese output, so apply()'s
+  // boot-time resolveLocale() must see preference 'zh' explicitly.
+  const settingsService = { get: (ns) => (ns === 'locale' ? { preference: 'zh' } : undefined) }
   const ctx = {
     state,
     tools: services.tools,
@@ -78,7 +85,7 @@ function fakeCtx(overrides = {}) {
       const disposer = fn()
       return disposer ?? (() => {})
     },
-    get: (key) => services[key],
+    get: (key) => services[key] ?? (key === 'settings' ? settingsService : undefined),
     logger: { warn: () => {}, info: () => {}, error: () => {} },
     ...overrides,
   }

--- a/tests/progressive-disclosure.test.js
+++ b/tests/progressive-disclosure.test.js
@@ -11,6 +11,10 @@ import { approveSuggestions } from '../lib/review.js'
 import { SuggestionQueue } from '../lib/store.js'
 import { TodoStore } from '../lib/todo.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** Whether `git` is available in this environment (skip git tests otherwise). */
 function gitAvailable() {
   try {
@@ -62,7 +66,9 @@ function fakeCtx(overrides = {}) {
       return { dispose: disposer ?? (() => {}) }
     },
     effect: (fn) => { const disposer = fn(); return disposer ?? (() => {}) },
-    get: (key) => services[key],
+    // apply() re-resolves the locale at boot; without a settings service it
+    // would fall back to 'en'. This suite pins Chinese output.
+    get: (key) => services[key] ?? (key === 'settings' ? { get: (ns) => (ns === 'locale' ? { preference: 'zh' } : undefined) } : undefined),
     logger: { warn: () => {}, info: () => {}, error: () => {} },
     ...overrides,
   }

--- a/tests/prompts.test.js
+++ b/tests/prompts.test.js
@@ -15,6 +15,10 @@ import {
   installPrompts, renderInjectionSnapshot,
 } from '../lib/prompts.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function tempDir() {
   return mkdtempSync(join(tmpdir(), 'dsh-memory-prompts-test-'))
 }

--- a/tests/review-i18n.test.js
+++ b/tests/review-i18n.test.js
@@ -1,0 +1,47 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { MemoryStore, SuggestionQueue } from '../lib/store.js'
+import { TodoStore } from '../lib/todo.js'
+import { approveSuggestions, enqueueSuggestion } from '../lib/review.js'
+import { setLocale, getLocale, translate, REVIEW_CMD_DICT } from '../lib/i18n.js'
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), 'dsh-review-i18n-'))
+}
+
+test('duplicate suggestions report as skipped (not failed) in every locale', () => {
+  const dir = tempDir()
+  const prevLocale = getLocale()
+  try {
+    const store = new MemoryStore(dir)
+    const todoStore = new TodoStore(dir)
+    const queue = new SuggestionQueue(join(dir, 'SUGGESTIONS.jsonl'))
+    enqueueSuggestion(queue, 'memory', 'Env fact A', 'because')
+    store.add('memory', 'Env fact A', undefined) // the suggestion now duplicates the stored entry
+
+    for (const locale of ['en', 'zh']) {
+      setLocale(locale)
+      // Re-enqueue for the second pass (the first approval consumed it).
+      if (locale !== 'en') enqueueSuggestion(queue, 'memory', 'Env fact B', 'because')
+      if (locale === 'zh') store.add('memory', 'Env fact B', undefined)
+
+      const expectedLine = translate(REVIEW_CMD_DICT, 'reviewcmd.existsSkip', { n: 1, target: 'memory' }, locale)
+      const report = approveSuggestions(store, todoStore, queue, [1], undefined)
+      assert.equal(report.lines.length, 1)
+      assert.equal(
+        report.lines[0],
+        expectedLine,
+        `[${locale}] duplicate must render as skipped`,
+      )
+      assert.equal(
+        report.remaining, 0, `[${locale}] duplicates are consumed`,
+      )
+    }
+  } finally {
+    setLocale(prevLocale)
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/tests/search-docs.test.js
+++ b/tests/search-docs.test.js
@@ -15,6 +15,10 @@ import {
   searchDocsCommand, searchDocsToolDefinition, searchFileContents,
 } from '../lib/search-docs.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** 快速构造一个已解析的插件配置。 */
 function baseConfig(overrides = {}) {
   return {

--- a/tests/session-orch.test.js
+++ b/tests/session-orch.test.js
@@ -12,6 +12,10 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { SessionOrch, SessionOrchStore, sessionToolDefinition, installSession } from '../lib/session-orch.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** 独立临时目录（每个测试隔离）。 */
 function tempDir() {
   return join(tmpdir(), `dsh-session-orch-test-${process.pid}-${Math.random().toString(36).slice(2, 10)}`)

--- a/tests/session-search.test.js
+++ b/tests/session-search.test.js
@@ -20,6 +20,10 @@ import {
 import { discoverCodexFiles, parseCodexFile } from '../lib/search/codex.js'
 import { runSessionSearch, sessionSearchToolDefinition, installSessionSearch } from '../lib/search/index.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** 清理所有临时目录。 */
 const temps = []
 after(() => {

--- a/tests/skills.test.js
+++ b/tests/skills.test.js
@@ -8,6 +8,10 @@ import {
   approvePendingSkill, listPendingSkills, rejectPendingSkill,
 } from '../lib/skills.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function tempDir() {
   return mkdtempSync(join(tmpdir(), 'dsh-skill-test-'))
 }

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -1,13 +1,18 @@
 import { test } from 'node:test'
+import { setLocale } from '../lib/i18n.js'
 import assert from 'node:assert/strict'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { todayStamp,
+
   ArchiveStore, MemoryStore, SuggestionQueue, isCanonical, parseEntries,
   parseEntryBranches, parseEntryDshOnly, projectHash, serializeEntries, splitEntryHead,
 } from '../lib/store.js'
+
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+setLocale('zh')
 
 /** Whether `git` is available in this environment (skip git tests otherwise). */
 function gitAvailable() {

--- a/tests/sync-api.test.js
+++ b/tests/sync-api.test.js
@@ -16,6 +16,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { installApi } from '../lib/api.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function tempDir() {
   return mkdtempSync(join(tmpdir(), 'dsh-sync-api-'))
 }

--- a/tests/sync-conflict.test.js
+++ b/tests/sync-conflict.test.js
@@ -17,6 +17,10 @@ import { ensureMemoryRepo, deviceBConnect } from '../lib/sync/repo.js'
 import { resolveProjectId } from '../lib/sync/identity.js'
 import { runSync, parseConflicts, resolveConflict, countConflicts } from '../lib/sync/worker.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/sync-e2e.test.js
+++ b/tests/sync-e2e.test.js
@@ -20,6 +20,10 @@ import { ensureMemoryRepo, deviceBConnect } from '../lib/sync/repo.js'
 import { resolveProjectId } from '../lib/sync/identity.js'
 import { runSync, resolveConflict, countConflicts } from '../lib/sync/worker.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/sync-entryid.test.js
+++ b/tests/sync-entryid.test.js
@@ -20,6 +20,10 @@ import {
   ENTRY_ID_RE, extractEntryId, ensureEntryIds, genEntryId, normalizeContent, stripEntryId,
 } from '../lib/sync/entryid.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function tempDir() {
   return mkdtempSync(join(tmpdir(), 'dsh-sync-entryid-'))
 }

--- a/tests/sync-global-final.test.js
+++ b/tests/sync-global-final.test.js
@@ -15,6 +15,10 @@ import { resolveProjectId } from '../lib/sync/identity.js'
 import { runSync, resolveConflict, countConflicts } from '../lib/sync/worker.js'
 import { globalBranchFor } from '../lib/sync/filesets.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/sync-global.test.js
+++ b/tests/sync-global.test.js
@@ -28,6 +28,10 @@ import { handleCommand, projectSyncInfo } from '../lib/sync/index.js'
 import { resolveProjectId } from '../lib/sync/identity.js'
 import { GLOBAL_FILESET_KEYS, globalBranchFor } from '../lib/sync/filesets.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/sync-identity.test.js
+++ b/tests/sync-identity.test.js
@@ -22,6 +22,10 @@ import {
 } from '../lib/sync/identity.js'
 import { projectHash, projectLabel } from '../lib/store.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** Whether `git` is available in this environment (skip git tests otherwise). */
 function gitAvailable() {
   try {

--- a/tests/sync-index.test.js
+++ b/tests/sync-index.test.js
@@ -22,6 +22,10 @@ import { ensureMemoryRepo, deviceBConnect } from '../lib/sync/repo.js'
 import { resolveProjectId } from '../lib/sync/identity.js'
 import { projectHash } from '../lib/store.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/sync-merge.test.js
+++ b/tests/sync-merge.test.js
@@ -13,6 +13,10 @@ import { mergeEntries } from '../lib/sync/merge.js'
 import { isCanonical, parseEntries, serializeEntries } from '../lib/store.js'
 import { extractEntryId, ensureEntryIds } from '../lib/sync/entryid.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 /** 快速构造一条带 ID 的条目（ID 补齐为 8 位 hex——身份证格式硬约束）。 */
 const E = (id, text) => `[id:${String(id).padEnd(8, '0')}] [2026-08-11] ${text}`
 const KEY = 'KEY.md'

--- a/tests/sync-repo.test.js
+++ b/tests/sync-repo.test.js
@@ -21,6 +21,10 @@ import { ensureMemoryRepo, deviceBConnect } from '../lib/sync/repo.js'
 import { resolveProjectId } from '../lib/sync/identity.js'
 import { projectHash } from '../lib/store.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/sync-review-final.test.js
+++ b/tests/sync-review-final.test.js
@@ -27,6 +27,10 @@ import { mergeEntries } from '../lib/sync/merge.js'
 import { handleCommand, projectSyncInfo } from '../lib/sync/index.js'
 import { isProjectSyncEnabled } from '../lib/store.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/sync-review-regression.test.js
+++ b/tests/sync-review-regression.test.js
@@ -21,6 +21,10 @@ import { extractEntryId } from '../lib/sync/entryid.js'
 import { ensureMemoryRepo, deviceBConnect } from '../lib/sync/repo.js'
 import { resolveProjectId } from '../lib/sync/identity.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/sync-shared-branch.test.js
+++ b/tests/sync-shared-branch.test.js
@@ -29,6 +29,10 @@ import { MODE_A_BRANCH, SHARED_BRANCH_PREFIX, decideModeBBranch, sharedBranchFor
 import { handleCommand, projectSyncInfo } from '../lib/sync/index.js'
 import { resolveProjectId } from '../lib/sync/identity.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/sync-worker.test.js
+++ b/tests/sync-worker.test.js
@@ -21,6 +21,10 @@ import { ensureMemoryRepo, deviceBConnect } from '../lib/sync/repo.js'
 import { resolveProjectId } from '../lib/sync/identity.js'
 import { runSync, runStatus, countConflicts } from '../lib/sync/worker.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function gitAvailable() {
   try {
     return spawnSync('git', ['--version'], { stdio: 'ignore' }).status === 0

--- a/tests/todo.test.js
+++ b/tests/todo.test.js
@@ -9,6 +9,10 @@ import { ArchiveStore, MemoryStore, SuggestionQueue, projectHash, todayStamp } f
 import { approveSuggestions, archiveSuggestions, enqueueSuggestion, promoteArchived } from '../lib/review.js'
 import { installApi } from '../lib/api.js'
 
+// This suite pins the legacy Chinese output contract; i18n.test.js covers English.
+import { setLocale } from '../lib/i18n.js'
+setLocale('zh')
+
 function tempDir() {
   return mkdtempSync(join(tmpdir(), 'dsh-memory-todo-test-'))
 }


### PR DESCRIPTION
## What

Full English support across the plugin, selected by the existing DSH **Settings → Language** preference (`zh` remains the default; nothing changes for current Chinese users).

### Host plane (`lib/i18n.js` + every user-facing module)
- New shared i18n module: `resolveLocale()` reads the DSH language preference (English by default, Chinese only when explicitly `zh`), 15 themed dictionaries, `translate(dict, key, params, locale)` with `{param}` interpolation and graceful key fallback.
- All tool/command/snapshot messages now render through it: dtodo, skills, prompts, session-orchestration (rename/spawn/wake/status/find), search-docs, advisor (command + runtime failure notes + store diagnostics + opt-in gates), aliases, canvas, updater, notify lookup, HTTP api archive/sync endpoints.
- Memory-sync (setup/sync/off/status/global/conflict/migrate) plus repo bootstrap and worker merge/push diagnostics.
- COI broadcast rooms/messages presence, scheduler dispatch errors, de_coi command help, adapters, attachment validation, session/task stores, ws-coordination, task-completion notification mail body.
- **Cross-process locale**: `spawnWorker` passes `DSH_LOCALE` to the sync worker child and the worker entry applies it at startup — worker messages match the host language instead of always English.

### Web client
- The plugin's 784-key zh/en dictionaries were already complete; `CoIView` now follows `navigator.language` instead of hardcoded Chinese, `AdvisorPanel` status/severity/outcome labels render bilingually, and leftover inline strings (notification-bell header parser, todo prefixes/cleanup reports, broadcast fallbacks, sync placeholder, COI notify mail) are localized or bilingual.
- The bell parser accepts both 中文 and English mail-field labels so notifications composed in either locale display correctly.

### Snapshot contract preserved
`buildSystemPromptSnapshot` keeps its section layout byte-identical per locale; English snapshots were verified against the same structural assertions as Chinese.

### Tests
- New `tests/i18n.test.js`: key-parity for every dictionary, resolveLocale behavior, snapshot rendering in both locales.
- Suites pinning the legacy Chinese output contract pin `setLocale('zh')` explicitly (the default remains English).
- Full suite: **757 pass / 3 fail**, where the 3 are pre-existing macOS-only tests (`/Volumes`, `mdfind`) failing identically on the unmodified baseline under Linux.

## Verification
- `node scripts/build.mjs` rebuilds `lib/client.js` cleanly with DSH_SOURCE pointing at the checkout.
- Host CJK scan: zero untranslated user-facing message/text literals remain outside `lib/i18n.js`.