### PR TITLE
feat: add todoEnabled runtime switch for disabling todo capability

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -119,6 +119,12 @@ function resolveSessionCwd(body, deps) {
  */
 export function installApi(ctx, deps) {
   const { store, archive, queue, todoStore, getRuntime, updateRuntime } = deps
+  const todoDisabled = () => getRuntime().todoEnabled === false
+  const sendTodoDisabled = (res) => sendJson(res, 503, {
+    ok: false,
+    code: 'TODO_DISABLED',
+    error: '待办功能未启用',
+  })
   // 会话别名（友好名称）：全局属性，不挂任何模块开关（随时可用）。
   // 优先用主插件共享实例（de_session rename 也写同一文件/内存缓存），
   // 未提供时自建（兼容测试等直接调用场景）
@@ -275,7 +281,7 @@ export function installApi(ctx, deps) {
             targets.set(index, target)
           }
         }
-        const report = approveSuggestions(store, todoStore, queue, indices, undefined, edits, targets)
+        const report = approveSuggestions(store, todoStore, queue, indices, undefined, edits, targets, { isTodoEnabled: () => !todoDisabled() })
         sendJson(res, 200, report)
         return
       }
@@ -313,6 +319,10 @@ export function installApi(ctx, deps) {
         const target = String(body?.target ?? '')
         const match = String(body?.match ?? '').trim()
         const isTodo = target.startsWith('todo-')
+        if (isTodo && todoDisabled()) {
+          sendTodoDisabled(res)
+          return
+        }
         if (target !== 'memory' && target !== 'user' && target !== 'key' && !isTodo) {
           throw new Error('target 必须是 memory / user / key / todo-*')
         }
@@ -328,6 +338,10 @@ export function installApi(ctx, deps) {
         const target = String(body?.target ?? '')
         const match = String(body?.match ?? '').trim()
         const isTodo = target.startsWith('todo-')
+        if (isTodo && todoDisabled()) {
+          sendTodoDisabled(res)
+          return
+        }
         if (target !== 'memory' && target !== 'user' && target !== 'key' && !isTodo) {
           throw new Error('target 必须是 memory / user / key / todo-*')
         }
@@ -340,7 +354,7 @@ export function installApi(ctx, deps) {
       }
       if (req.method === 'POST' && path === '/memory-evolve/api/suggestions/approve-all') {
         const all = Array.from({ length: queue.read().length }, (_, i) => i + 1)
-        sendJson(res, 200, approveSuggestions(store, todoStore, queue, all, undefined))
+        sendJson(res, 200, approveSuggestions(store, todoStore, queue, all, undefined, undefined, undefined, { isTodoEnabled: () => !todoDisabled() }))
         return
       }
       if (req.method === 'POST' && path === '/memory-evolve/api/suggestions/reject-all') {
@@ -666,6 +680,10 @@ export function installApi(ctx, deps) {
         return
       }
       if (req.method === 'GET' && path === '/memory-evolve/api/todo') {
+        if (todoDisabled()) {
+          sendTodoDisabled(res)
+          return
+        }
         // Todo list for the 待办 sub-tab. `target` optional (default all
         // four tracks); `all=1` shows everything (the tab defaults to the
         // smart view like the dtodo tool); `past=1` also reads the daily
@@ -696,6 +714,10 @@ export function installApi(ctx, deps) {
         return
       }
       if (req.method === 'POST' && path === '/memory-evolve/api/todo') {
+        if (todoDisabled()) {
+          sendTodoDisabled(res)
+          return
+        }
         // Todo mutations from the 待办 sub-tab (user is the confirmer: direct
         // writes). Actions: add / done / update / remove.
         const body = await readBody(req)

--- a/lib/client.js
+++ b/lib/client.js
@@ -35,6 +35,39 @@ var import_react2 = require("react");
 
 // src/client/MemoryQueueView.tsx
 var import_react = require("react");
+
+// src/client/todo-tab-lifecycle.js
+var RUNTIME_CONFIG_CHANGED = "dsh-memory-evolve:runtime-config-changed";
+function createTodoTabLifecycle(register) {
+  let enabled = false;
+  let disposer;
+  const mount = () => {
+    disposer?.();
+    disposer = register();
+  };
+  return {
+    setEnabled(next) {
+      enabled = next === true;
+      if (!enabled) {
+        disposer?.();
+        disposer = void 0;
+      } else if (disposer === void 0) {
+        mount();
+      }
+    },
+    refresh() {
+      if (enabled && disposer !== void 0) mount();
+    },
+    dispose() {
+      enabled = false;
+      disposer?.();
+      disposer = void 0;
+    },
+    enabled: () => enabled
+  };
+}
+
+// src/client/MemoryQueueView.tsx
 var import_jsx_runtime = require("react/jsx-runtime");
 function todoTargetLabel(t2, target) {
   const track = target.slice(5);
@@ -169,6 +202,7 @@ function MemoryQueueView(props) {
       modelsEnabled: draft.modelsEnabled,
       uiSettingsEnabled: draft.uiSettingsEnabled,
       bookmarkEnabled: draft.bookmarkEnabled,
+      todoEnabled: draft.todoEnabled,
       notifyEnabled: draft.notifyEnabled,
       syncEnabled: draft.syncEnabled,
       canvasEnabled: draft.canvasEnabled,
@@ -182,6 +216,7 @@ function MemoryQueueView(props) {
     }).then((res) => {
       setConfig(res.config);
       setDraft(res.config);
+      window.dispatchEvent(new CustomEvent(RUNTIME_CONFIG_CHANGED, { detail: res.config }));
       setNotice({ kind: "ok", text: t2("panel.config.saved") });
     }).catch((error) => {
       setNotice({ kind: "error", text: t2("panel.config.failed", { message: error.message }) });
@@ -834,6 +869,21 @@ function MemoryQueueView(props) {
                 className: "me-switch",
                 checked: draft.bookmarkEnabled,
                 onChange: (event) => patchDraft({ bookmarkEnabled: event.target.checked })
+              }
+            )
+          ] }),
+          /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("label", { className: "me-field", children: [
+            /* @__PURE__ */ (0, import_jsx_runtime.jsxs)("span", { className: "me-field-label", children: [
+              t2("panel.config.todoEnabled"),
+              /* @__PURE__ */ (0, import_jsx_runtime.jsx)("em", { className: "me-field-hint", children: t2("panel.config.todoEnabled.hint") })
+            ] }),
+            /* @__PURE__ */ (0, import_jsx_runtime.jsx)(
+              "input",
+              {
+                type: "checkbox",
+                className: "me-switch",
+                checked: draft.todoEnabled,
+                onChange: (event) => patchDraft({ todoEnabled: event.target.checked })
               }
             )
           ] })
@@ -16369,6 +16419,8 @@ var zh = {
   "panel.guide.bookmark.desc": "\u7ED9\u6BCF\u8F6E\u6253\u661F\u6807\u8BB0\uFF0C\u5217\u8868\u4E00\u952E\u8DF3\u56DE\uFF0C\u5E76\u652F\u6301\u4ECE\u4EFB\u610F\u8F6E\u521B\u5EFA\u5B98\u65B9\u5206\u652F\uFF08\u542B\u63A5\u7BA1\u5B98\u65B9\u4E2D\u95F4\u8F6E\u5206\u652F\u6309\u94AE\uFF09\u3002\u72EC\u7ACB\u5F00\u5173\uFF0C\u9ED8\u8BA4\u5173\u3002",
   "panel.config.bookmarkEnabled": "\u4F1A\u8BDD\u4E66\u7B7E",
   "panel.config.bookmarkEnabled.hint": "\u542F\u7528\u4F1A\u8BDD\u4E66\u7B7E\uFF1A\u6BCF\u4E2A\u5DF2\u5B8C\u6210\u8F6E\u5C3E\u51FA\u73B0 \u2606 \u661F\u6807\u6309\u94AE + \u300C\u4E66\u7B7E\u300DTab \u5217\u8868\u4E0E\u8DF3\u8F6C\uFF1B\u652F\u6301\u4ECE\u4EFB\u610F\u8F6E\u521B\u5EFA\u5B98\u65B9\u5206\u652F\uFF08\u5217\u8868\u300C\u5206\u652F\u300D\u6309\u94AE\uFF0C\u6216\u76F4\u63A5\u70B9\u5B98\u65B9\u5206\u652F\u6309\u94AE\u2014\u2014\u4E2D\u95F4\u8F6E\u4F1A\u88AB\u63A5\u7BA1\u5E76\u5F39\u786E\u8BA4\uFF09\u3002\u6570\u636E\u5B58\u5728 <memoryDir>/session-bookmarks.json\uFF08\u6309\u4F1A\u8BDD\u9694\u79BB\uFF0C\u6309\u8F6E seq \u5B9A\u4F4D\uFF09\u3002**\u72EC\u7ACB\u5B50\u6A21\u5757**\uFF08\u9ED8\u8BA4\u5173\u95ED\uFF0C\u7EAF UI + \u5BBF\u4E3B API\uFF0C\u4E0D\u6CE8\u518C AI \u5DE5\u5177\uFF09\uFF1B\u5173\u95ED\u65F6\u661F\u6807\u4E0E Tab \u9690\u85CF\uFF0C\u6570\u636E\u6587\u4EF6\u4FDD\u7559\u3002",
+  "panel.config.todoEnabled": "\u5F85\u529E\u529F\u80FD",
+  "panel.config.todoEnabled.hint": "\u542F\u7528 dtodo \u5DE5\u5177\u3001\u5F85\u529E Tab \u548C\u5230\u671F\u63D0\u9192\u3002\u5173\u95ED\u540E\u7ACB\u5373\u9690\u85CF Tab\u3001\u505C\u6B62\u5F85\u529E\u5199\u5165\uFF1B\u73B0\u6709\u5F85\u529E\u6570\u636E\u548C\u540C\u6B65\u8F68\u4FDD\u6301\u4E0D\u53D8\u3002",
   // 以下键保留兼容（旧 memory tab 合并布局的遗留，新 UI 不再引用）：
   "memoryTab.feature.config": "\u914D\u7F6E",
   "memoryTab.feature.todoSuggestions": "\u5F85\u786E\u8BA4\u5F85\u529E\u5EFA\u8BAE",
@@ -17171,6 +17223,8 @@ var en = {
   "panel.guide.bookmark.desc": "Star any turn and jump back from the list; fork official branch sessions from any turn (including taking over official mid-turn branch buttons). Independent switch, off by default.",
   "panel.config.bookmarkEnabled": "Session bookmarks",
   "panel.config.bookmarkEnabled.hint": 'Enable session bookmarks: a \u2606 star on each completed turn tail + a Bookmarks tab for the list and jump; fork official branch sessions from any turn (list "Fork" button, or click the official branch button \u2014 mid-turn buttons are taken over with a confirm dialog). Data lives in <memoryDir>/session-bookmarks.json (per-session, keyed by turn seq). **Independent submodule** (off by default; pure UI + host API, no AI tools); when off, stars and the tab hide, the data file is kept.',
+  "panel.config.todoEnabled": "Todos",
+  "panel.config.todoEnabled.hint": "Enable the dtodo tool, Todos tab, and due reminders. When off, the tab hides immediately and todo writes stop; existing data and the sync track stay intact.",
   // Legacy keys kept for compatibility (old merged memory-tab layout).
   "memoryTab.feature.config": "Config",
   "memoryTab.feature.todoSuggestions": "Todo suggestions",
@@ -17702,7 +17756,6 @@ function apply(ctx) {
   let todosBadgeCount = 0;
   let disposeMemoryTab;
   let disposeSkillsTab;
-  let disposeTodosTab;
   const registerMemoryTab = () => {
     disposeMemoryTab?.();
     disposeMemoryTab = ctx.slots.inject("conversation.view", () => ctx.slots.register({
@@ -17721,15 +17774,18 @@ function apply(ctx) {
       label: () => skillsBadgeCount > 0 ? t2("skillsTab.label.pending", { count: skillsBadgeCount }) : t2("skillsTab.label")
     }, (props) => SkillsTabView({ ...props, t: t2 })));
   };
-  const registerTodosTab = () => {
-    disposeTodosTab?.();
-    disposeTodosTab = ctx.slots.inject("conversation.view", () => ctx.slots.register({
-      name: "conversation.view",
-      id: "todos-hub",
-      order: 30,
-      label: () => todosBadgeCount > 0 ? t2("todosTab.label.pending", { count: todosBadgeCount }) : t2("todosTab.label")
-    }, (props) => TodosTabView({ ...props, t: t2 })));
+  const todoTabLifecycle = createTodoTabLifecycle(() => ctx.slots.inject("conversation.view", () => ctx.slots.register({
+    name: "conversation.view",
+    id: "todos-hub",
+    order: 30,
+    label: () => todosBadgeCount > 0 ? t2("todosTab.label.pending", { count: todosBadgeCount }) : t2("todosTab.label")
+  }, (props) => TodosTabView({ ...props, t: t2 }))));
+  const onRuntimeConfigChanged = (event) => {
+    const detail = event.detail;
+    todoTabLifecycle.setEnabled(detail?.todoEnabled !== false);
   };
+  window.addEventListener(RUNTIME_CONFIG_CHANGED, onRuntimeConfigChanged);
+  ctx.effect(() => () => window.removeEventListener(RUNTIME_CONFIG_CHANGED, onRuntimeConfigChanged), "memory-evolve: todo tab runtime listener");
   let disposeSettingsTab;
   const registerSettingsTab = () => {
     disposeSettingsTab?.();
@@ -17781,7 +17837,7 @@ function apply(ctx) {
       }
       if (todoSuggestions !== todosBadgeCount) {
         todosBadgeCount = todoSuggestions;
-        registerTodosTab();
+        todoTabLifecycle.refresh();
       }
     }).catch(() => {
     });
@@ -17796,7 +17852,7 @@ function apply(ctx) {
     if (tabCancelled || data.config?.memoryTabEnabled !== true) return;
     registerMemoryTab();
     registerSkillsTab();
-    registerTodosTab();
+    todoTabLifecycle.setEnabled(data.config?.todoEnabled !== false);
     registerSettingsTab();
     pollBadge();
     const timer = setInterval(pollBadge, BADGE_POLL_MS);
@@ -17819,7 +17875,7 @@ function apply(ctx) {
     tabCancelled = true;
     disposeMemoryTab?.();
     disposeSkillsTab?.();
-    disposeTodosTab?.();
+    todoTabLifecycle.dispose();
     disposeSettingsTab?.();
   }, "memory-evolve: memory tabs");
   ctx.effect(() => () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ import { reviewCommand, reviewStatusTool, reviewTurnCounter, enqueueSuggestion, 
 import { skillManageTool } from './skills.js'
 import { installApi } from './api.js'
 import { installSkillsManager } from './skills-manager.js'
-import { TodoStore, todoToolDefinition } from './todo.js'
+import { TodoStore, createTodoController } from './todo.js'
 import { installMemorySync, makeProjectDirResolver } from './sync/index.js'
 import { createSearchDocsController, searchDocsCommand } from './search-docs.js'
 import { installBroadcast, installCoi } from './coi/index.js'
@@ -66,7 +66,7 @@ export const name = 'dsh-memory-evolve'
 export const inject = ['tools', 'systemPrompt', 'agents', 'workspaceRegistry', 'sessionTitle', 'sessionPersistence', 'settings', 'llm']
 
 /** Plugin config defaults (conservative: review off, memory on). */
-const DEFAULTS = {
+export const DEFAULTS = {
   // storage
   memoryDir: null, // null → <dshHome>/memories
   entryDatePrefix: true,
@@ -89,6 +89,9 @@ const DEFAULTS = {
   commandName: 'memory_review',
   skillManageToolName: 'skill_manage',
   todoToolName: 'dtodo',
+  // Backward-compatible runtime capability: missing keys in old config/state
+  // files resolve to enabled, preserving existing dtodo behaviour.
+  todoEnabled: true,
   // skill management
   skillDir: null, // null → ~/.agents/skills (the DSH skill library)
   skillMaxBytes: 65536,
@@ -252,6 +255,7 @@ export const RUNTIME_KEYS = [
   'searchDocsEnabled', 'coiEnabled', 'broadcastEnabled', 'promptsEnabled',
   'sessionSearchEnabled', 'sessionEnabled', 'modelsEnabled', 'uiSettingsEnabled',
   'bookmarkEnabled', 'searchDocsMode',
+  'todoEnabled',
   'wsCoordEnabled', 'wsCoordEnforceWrite', 'wsCoordSnapshot',
   'notifyEnabled', 'channelSendEnabled', 'broadcastImageEnabled',
   'sessionImageQueryEnabled', 'syncEnabled',
@@ -291,6 +295,7 @@ export function validateRuntimePatch(key, value) {
     case 'modelsEnabled':
     case 'uiSettingsEnabled':
     case 'bookmarkEnabled':
+    case 'todoEnabled':
     case 'wsCoordEnabled':
     case 'wsCoordEnforceWrite':
     case 'wsCoordSnapshot':
@@ -388,6 +393,7 @@ const BOOLEAN_KEYS = [
   'perTurnProjectWrites', 'perTurnDailyWrites', 'perTurnKeyWrites',
   'searchDocsEnabled', 'coiEnabled', 'coiSummaryEnabled', 'coiSyncSkills',
   'promptsEnabled', 'sessionSearchEnabled', 'sessionEnabled',
+  'todoEnabled',
   'notifyEnabled', 'channelSendEnabled', 'broadcastImageEnabled',
   'sessionImageQueryEnabled', 'syncEnabled',
   'advisorEnabled', 'advisorPanelEnabled',
@@ -626,9 +632,9 @@ export function renderSnapshot(config, store, agent, counter, sessionTitleServic
   const branchHint = branch !== undefined
     ? `\n- 当前 git 分支：**${branch}**（target=key 的记忆按分支过滤注入；写 key 时可用 branches=分支名 限定范围，缺省=全部）`
     : ''
-  parts.push(`## 记忆 memory-evolve（包含 memory 工具、dtodo 待办工具、skill_manage 技能工具）
-- 读取：需要时用 memory 工具读取 target=project（项目约定/进展）与 target=daily（今日日志），不要凭猜测回答。本项目关键记忆（target=key）已注入上下文，无需读取。${branchHint}
-- 待办（dtodo）：收尾时调用 dtodo list 检查到期（默认视图：今日到期/逾期优先，最多 8 条）——有到期未完成项就在回复末尾提醒用户；不要主动展开全部待办清单，除非用户询问；用法细节（target 归类、过往/过期查询等）见 dtodo 工具描述。`)
+  const todoEnabled = config.todoEnabled !== false
+  parts.push(`## 记忆 memory-evolve（包含 memory 工具、${todoEnabled ? 'dtodo 待办工具、' : ''}skill_manage 技能工具）
+- 读取：需要时用 memory 工具读取 target=project（项目约定/进展）与 target=daily（今日日志），不要凭猜测回答。本项目关键记忆（target=key）已注入上下文，无需读取。${branchHint}${todoEnabled ? '\n- 待办（dtodo）：收尾时调用 dtodo list 检查到期（默认视图：今日到期/逾期优先，最多 8 条）——有到期未完成项就在回复末尾提醒用户；不要主动展开全部待办清单，除非用户询问；用法细节（target 归类、过往/过期查询等）见 dtodo 工具描述。' : ''}`)
 
   // Turn-final duties, as one minimal checklist (write → review when the
   // snapshot says so). No per-turn status check: the program injects a
@@ -1501,6 +1507,7 @@ export function apply(ctx, rawConfig = {}) {
     channelSendCtrl.sync() // 渠道直发随 channelSendEnabled 即时安装/卸载（独立开关，与 notify 互不影响）
     sessionImageCtrl.sync() // 本会话图片查询随 sessionImageQueryEnabled 即时安装/卸载（独立开关）
     searchDocsCtrl.sync()
+    todoCtrl.sync()
     coiCtrl.sync() // COI 模块随 coiEnabled 即时安装/卸载
     broadcastCtrl.sync() // 会话广播随 broadcastEnabled 即时安装/卸载
     sessionSearchCtrl.sync() // 会话搜索随 sessionSearchEnabled 即时安装/卸载
@@ -1538,9 +1545,9 @@ export function apply(ctx, rawConfig = {}) {
   //     subagent for the skill track).
   ctx.effect(() => ctx.tools.register(skillManageTool(ctx, config)), 'dsh-memory-evolve: skill tool')
 
-  // 2c. The todo tool (always registered: user-spoken todos are written
-  //     directly; model-authored ones go through the suggestion queue).
-  ctx.effect(() => ctx.tools.register(todoToolDefinition(config, todoStore)), 'dsh-memory-evolve: todo tool')
+  // 2c. The todo capability: the controller owns only the tool registration;
+  // data stays intact while disabled and resumes immediately when re-enabled.
+  const todoCtrl = createTodoController(ctx, config, getRuntime, todoStore)
 
   // 3. In-turn review (opt-in): suggest tool + turn counter + status tool.
   // Machinery is installed whenever the plugin loads (config reviewEnabled OR
@@ -1549,7 +1556,7 @@ export function apply(ctx, rawConfig = {}) {
   // inside the main LLM's turn (prompt-driven, see renderSnapshot).
   const reviewWanted = config.reviewEnabled || runtime.reviewEnabled
   if (reviewWanted) {
-    ctx.effect(() => ctx.tools.register(suggestToolDefinition(config, queue)), 'dsh-memory-evolve: suggest tool')
+    ctx.effect(() => ctx.tools.register(suggestToolDefinition(config, queue, () => getRuntime().todoEnabled !== false)), 'dsh-memory-evolve: suggest tool')
     ctx.effect(() => ctx.tools.register(reviewStatusTool(getRuntime, counter)), 'dsh-memory-evolve: review status tool')
   }
 
@@ -1661,7 +1668,7 @@ export function apply(ctx, rawConfig = {}) {
   //    want to inspect/clean leftover suggestions). Registered when the
   //    commands service exists.
   ctx.inject(['commands'], (cmdCtx) => {
-    cmdCtx.commands.register(reviewCommand(config, store, todoStore, archive, queue))
+    cmdCtx.commands.register(reviewCommand(config, store, todoStore, archive, queue, () => getRuntime().todoEnabled !== false))
     cmdCtx.commands.register(searchDocsCommand(config, {
       status: () => searchDocsCtrl.status(),
       setEnabled: (enabled) => applyRuntimePatch({ searchDocsEnabled: enabled }),

--- a/lib/review.js
+++ b/lib/review.js
@@ -156,7 +156,7 @@ export function reviewStatusTool(getRuntime, counter) {
  * @param {import('./store.js').SuggestionQueue} queue - the suggestion queue.
  * @returns {object} a ToolDefinition-shaped object for ctx.tools.register.
  */
-export function suggestToolDefinition(config, queue) {
+export function suggestToolDefinition(config, queue, isTodoEnabled = () => true) {
   return {
     name: config.suggestToolName,
     description: '提出一条长期记忆建议（记忆审查使用）。不会直接修改记忆，只会加入待用户确认的队列；重复内容会累计建议次数。',
@@ -199,6 +199,9 @@ export function suggestToolDefinition(config, queue) {
       const validTargets = ['memory', 'user', 'todo-life', 'todo-work', 'todo-project', 'todo-daily']
       if (!validTargets.includes(target)) {
         return { ok: false, message: `无效 target "${target}"（应为 ${validTargets.join('/')}）` }
+      }
+      if (target.startsWith('todo-') && !isTodoEnabled()) {
+        return { ok: false, code: 'TODO_DISABLED', message: '待办功能未启用' }
       }
       if (!content) return { ok: false, message: 'content 不能为空' }
       if (!reason) return { ok: false, message: 'reason 不能为空（必须引用会话中的证据）' }
@@ -278,7 +281,8 @@ export function enqueueSuggestion(queue, target, content, reason, agent) {
  *   override (1-based; 'memory' | 'user' | 'key' — todo-* entries ignore it).
  * @returns {{lines: string[], remaining: number}} a report for callers.
  */
-export function approveSuggestions(store, todoStore, queue, indices, agent, edits, targets) {
+export function approveSuggestions(store, todoStore, queue, indices, agent, edits, targets, options = {}) {
+  const isTodoEnabled = options.isTodoEnabled ?? (() => true)
   return queue.mutate((entries) => {
     const kept = []
     const lines = []
@@ -300,6 +304,11 @@ export function approveSuggestions(store, todoStore, queue, indices, agent, edit
       const edited = edits?.get(number)?.trim()
       const content = edited ? edited : entry.content
       const isTodo = target.startsWith('todo-')
+      if (isTodo && !isTodoEnabled()) {
+        lines.push(`✗ #${number} [${target}] TODO_DISABLED：待办功能未启用`)
+        kept.push(entry)
+        return
+      }
       let outcome
       if (isTodo) {
         outcome = todoStore.addTodo(target.slice(5), content, {}, entry.cwd ?? agent?.session?.header?.cwd)
@@ -434,7 +443,7 @@ export function promoteArchived(store, todoStore, archive, target, match, cwd) {
  * @param {import('./store.js').SuggestionQueue} queue - the suggestion queue.
  * @returns {object} a CommandDefinition-shaped object for ctx.commands.register.
  */
-export function reviewCommand(config, store, todoStore, archive, queue) {
+export function reviewCommand(config, store, todoStore, archive, queue, isTodoEnabled = () => true) {
   const formatEntry = (entry, index) => `${index + 1}. [${entry.target}] ${entry.content}（理由：${entry.reason ?? '无'}）`
 
   return {
@@ -459,7 +468,7 @@ export function reviewCommand(config, store, todoStore, archive, queue) {
         }
         case 'approve': {
           if (!validIndices) return { kind: 'error', text: '用法：approve <序号>…（序号来自 list）' }
-          const report = approveSuggestions(store, todoStore, queue, indices, invocation.agent)
+          const report = approveSuggestions(store, todoStore, queue, indices, invocation.agent, undefined, undefined, { isTodoEnabled })
           return {
             kind: 'success',
             text: `${report.lines.join('\n')}\n剩余待确认：${report.remaining} 条`,
@@ -483,7 +492,7 @@ export function reviewCommand(config, store, todoStore, archive, queue) {
         }
         case 'approve-all': {
           const all = Array.from({ length: queue.read().length }, (_, i) => i + 1)
-          const report = approveSuggestions(store, todoStore, queue, all, invocation.agent)
+          const report = approveSuggestions(store, todoStore, queue, all, invocation.agent, undefined, undefined, { isTodoEnabled })
           return {
             kind: 'success',
             text: `${report.lines.join('\n')}\n剩余待确认：${report.remaining} 条`,

--- a/lib/todo.js
+++ b/lib/todo.js
@@ -564,7 +564,7 @@ function resolveQuadrant(args) {
  * @param {import('./todo.js').TodoStore} todoStore - the todo store.
  * @returns {object} a tool definition for ctx.tools.register.
  */
-export function todoToolDefinition(config, todoStore) {
+export function todoToolDefinition(config, todoStore, isTodoEnabled = () => true) {
   return {
     name: config.todoToolName,
     description: '待办管理（四轨：life 生活 / work 工作 / project 项目（按工作目录隔离）/ daily 每日）。用户口述"记住/我要做 X"时用 add 直写——**add 的 target 遵循用户说的类别**（"工作上的事"→work、"生活中的"→life、"这个项目要"→project、"今天要"→daily），用户没说才用缺省（有工作目录 project，无 cwd 用 work）。**list 默认智能视图**：只返回需要关注的未完成项（逾期/今日到期/当前项目/重要紧急，最多 8 条），看全部需显式 all=true 或筛选参数。**查过往（昨天及更早的每日待办）请一次到位：list 加 past=true 且 expired=true**——每日待办截止=当天，过往的每日待办几乎必然已过期（除非已完成），只带 past=true 会隐藏未完成的过期遗留（只能看到已完成的过往）；带齐两个参数才能看到"昨天有哪些待办、哪些没做完"。**跨项目查询**：在别的会话里查某项目的待办用 list 加 target=project 与 cwd=<该项目工作目录路径>。done/update/remove 按 id 精确操作（list 输出带 id；每日过往条目的 id 同样可操作）。模型自建待办请用 memory_suggest target=todo-*（进待确认队列），不要直接 add。',
@@ -603,6 +603,7 @@ export function todoToolDefinition(config, todoStore) {
         additionalProperties: false,
         properties: {
           ok: { type: 'boolean' },
+          code: { type: 'string', description: '机器可判定的失败码（待办关闭时为 TODO_DISABLED）' },
           message: { type: 'string' },
           target: { type: 'string' },
           id: { type: 'string', description: 'add 成功时返回新条目的 id（后续 done/update/remove 用）' },
@@ -612,6 +613,12 @@ export function todoToolDefinition(config, todoStore) {
       render: (_args, value) => [{ type: 'text', text: value.message ?? '' }],
     },
     async execute(args, exec) {
+      // Tool schemas may have been emitted before a runtime switch. Keep this
+      // live guard so an already-captured invocation cannot write after the
+      // todo capability has been disabled.
+      if (!isTodoEnabled()) {
+        return { ok: false, code: 'TODO_DISABLED', message: '待办功能未启用' }
+      }
       const action = args.action
       const cwd = exec?.agent?.session?.header?.cwd ?? undefined
       const dateArg = (value) => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : undefined
@@ -665,4 +672,24 @@ export function todoToolDefinition(config, todoStore) {
       return { ok: false, message: `未知 action "${action}"` }
     },
   }
+}
+
+/**
+ * Runtime lifecycle for the dtodo capability. Storage deliberately stays
+ * outside this controller: disabling is reversible and must never alter
+ * existing todo files or the independent sync track.
+ */
+export function createTodoController(ctx, config, getRuntime, todoStore) {
+  let disposer = null
+  const enabled = () => getRuntime().todoEnabled !== false
+  const sync = () => {
+    if (enabled() && disposer === null) {
+      disposer = ctx.tools.register(todoToolDefinition(config, todoStore, enabled))
+    } else if (!enabled() && disposer !== null) {
+      disposer()
+      disposer = null
+    }
+  }
+  sync()
+  return { sync, enabled }
 }

--- a/src/client/MemoryQueueView.tsx
+++ b/src/client/MemoryQueueView.tsx
@@ -11,6 +11,7 @@
  */
 import { useEffect, useState } from 'react'
 import type { Translate } from '@deepseek-ai/dsh-client-ui-slots'
+import { RUNTIME_CONFIG_CHANGED } from './todo-tab-lifecycle.js'
 
 /** Which feature sub-tab is active. */
 export type MemoryFeature = 'guide' | 'suggestions' | 'todo-suggestions' | 'skills' | 'config'
@@ -114,6 +115,8 @@ interface RuntimeConfig {
   uiSettingsEnabled: boolean
   /** 会话书签（独立子模块，默认关）。 */
   bookmarkEnabled: boolean
+  /** 待办能力（默认开；关闭时工具、Tab 和提示词一并退出）。 */
+  todoEnabled: boolean
   /** 渠道通知（de_notify，独立子模块，默认关）：AI 完成任务后经 IM 渠道主动发通知。 */
   notifyEnabled: boolean
   /** 项目记忆跨设备同步（/memory_sync，独立子模块，默认关）：Git 对账。 */
@@ -269,6 +272,7 @@ export function MemoryQueueView(props: MemoryQueueViewProps): JSX.Element {
       modelsEnabled: draft.modelsEnabled,
       uiSettingsEnabled: draft.uiSettingsEnabled,
       bookmarkEnabled: draft.bookmarkEnabled,
+      todoEnabled: draft.todoEnabled,
       notifyEnabled: draft.notifyEnabled,
       syncEnabled: draft.syncEnabled,
       canvasEnabled: draft.canvasEnabled,
@@ -282,6 +286,7 @@ export function MemoryQueueView(props: MemoryQueueViewProps): JSX.Element {
     }).then((res) => {
       setConfig(res.config)
       setDraft(res.config)
+      window.dispatchEvent(new CustomEvent(RUNTIME_CONFIG_CHANGED, { detail: res.config }))
       setNotice({ kind: 'ok', text: t('panel.config.saved') })
     }).catch((error: Error) => {
       setNotice({ kind: 'error', text: t('panel.config.failed', { message: error.message }) })
@@ -923,6 +928,18 @@ export function MemoryQueueView(props: MemoryQueueViewProps): JSX.Element {
                     className="me-switch"
                     checked={draft.bookmarkEnabled}
                     onChange={(event) => patchDraft({ bookmarkEnabled: event.target.checked })}
+                  />
+                </label>
+                <label className="me-field">
+                  <span className="me-field-label">
+                    {t('panel.config.todoEnabled')}
+                    <em className="me-field-hint">{t('panel.config.todoEnabled.hint')}</em>
+                  </span>
+                  <input
+                    type="checkbox"
+                    className="me-switch"
+                    checked={draft.todoEnabled}
+                    onChange={(event) => patchDraft({ todoEnabled: event.target.checked })}
                   />
                 </label>
               </div>

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -53,6 +53,7 @@ import mobileCss from './mobile.css'
 import { createInputSheetEnhance } from './mobile-input-sheet'
 import { createNotificationBell } from './notification-bell.tsx'
 import notificationStyles from './notification-styles.css'
+import { createTodoTabLifecycle, RUNTIME_CONFIG_CHANGED } from './todo-tab-lifecycle.js'
 
 /** Locale namespace owned by this plugin. */
 const NS = 'memory-evolve'
@@ -517,6 +518,8 @@ export const zh = {
   'panel.guide.bookmark.desc': '给每轮打星标记，列表一键跳回，并支持从任意轮创建官方分支（含接管官方中间轮分支按钮）。独立开关，默认关。',
   'panel.config.bookmarkEnabled': '会话书签',
   'panel.config.bookmarkEnabled.hint': '启用会话书签：每个已完成轮尾出现 ☆ 星标按钮 + 「书签」Tab 列表与跳转；支持从任意轮创建官方分支（列表「分支」按钮，或直接点官方分支按钮——中间轮会被接管并弹确认）。数据存在 <memoryDir>/session-bookmarks.json（按会话隔离，按轮 seq 定位）。**独立子模块**（默认关闭，纯 UI + 宿主 API，不注册 AI 工具）；关闭时星标与 Tab 隐藏，数据文件保留。',
+  'panel.config.todoEnabled': '待办功能',
+  'panel.config.todoEnabled.hint': '启用 dtodo 工具、待办 Tab 和到期提醒。关闭后立即隐藏 Tab、停止待办写入；现有待办数据和同步轨保持不变。',
   // 以下键保留兼容（旧 memory tab 合并布局的遗留，新 UI 不再引用）：
   'memoryTab.feature.config': '配置',
   'memoryTab.feature.todoSuggestions': '待确认待办建议',
@@ -1321,6 +1324,8 @@ export const en: Record<MemoryEvolveKey, string> = {
   'panel.guide.bookmark.desc': 'Star any turn and jump back from the list; fork official branch sessions from any turn (including taking over official mid-turn branch buttons). Independent switch, off by default.',
   'panel.config.bookmarkEnabled': 'Session bookmarks',
   'panel.config.bookmarkEnabled.hint': 'Enable session bookmarks: a ☆ star on each completed turn tail + a Bookmarks tab for the list and jump; fork official branch sessions from any turn (list "Fork" button, or click the official branch button — mid-turn buttons are taken over with a confirm dialog). Data lives in <memoryDir>/session-bookmarks.json (per-session, keyed by turn seq). **Independent submodule** (off by default; pure UI + host API, no AI tools); when off, stars and the tab hide, the data file is kept.',
+  'panel.config.todoEnabled': 'Todos',
+  'panel.config.todoEnabled.hint': 'Enable the dtodo tool, Todos tab, and due reminders. When off, the tab hides immediately and todo writes stop; existing data and the sync track stay intact.',
   // Legacy keys kept for compatibility (old merged memory-tab layout).
   'memoryTab.feature.config': 'Config',
   'memoryTab.feature.todoSuggestions': 'Todo suggestions',
@@ -1903,7 +1908,6 @@ export function apply(ctx: Context): void {
   let todosBadgeCount = 0
   let disposeMemoryTab: (() => void) | undefined
   let disposeSkillsTab: (() => void) | undefined
-  let disposeTodosTab: (() => void) | undefined
 
   const registerMemoryTab = (): void => {
     disposeMemoryTab?.()
@@ -1925,16 +1929,19 @@ export function apply(ctx: Context): void {
         label: () => (skillsBadgeCount > 0 ? t('skillsTab.label.pending', { count: skillsBadgeCount }) : t('skillsTab.label')),
       }, (props) => SkillsTabView({ ...props, t })))
   }
-  const registerTodosTab = (): void => {
-    disposeTodosTab?.()
-    disposeTodosTab = ctx.slots.inject('conversation.view', () =>
+  const todoTabLifecycle = createTodoTabLifecycle(() => ctx.slots.inject('conversation.view', () =>
       ctx.slots.register({
         name: 'conversation.view',
         id: 'todos-hub',
         order: 30,
         label: () => (todosBadgeCount > 0 ? t('todosTab.label.pending', { count: todosBadgeCount }) : t('todosTab.label')),
-      }, (props) => TodosTabView({ ...props, t })))
+      }, (props) => TodosTabView({ ...props, t }))))
+  const onRuntimeConfigChanged = (event: Event): void => {
+    const detail = (event as CustomEvent<{ todoEnabled?: boolean }>).detail
+    todoTabLifecycle.setEnabled(detail?.todoEnabled !== false)
   }
+  window.addEventListener(RUNTIME_CONFIG_CHANGED, onRuntimeConfigChanged)
+  ctx.effect(() => () => window.removeEventListener(RUNTIME_CONFIG_CHANGED, onRuntimeConfigChanged), 'memory-evolve: todo tab runtime listener')
   // 设置 Tab（Memory Evolve 设置，order 120 放最后）：整体指南 + 配置 + 版本。
   // 红点：检测到新发布版本时 label 变 🔴 变体（updateBadgeCount 驱动，重注册
   // 生效；无红点时注册一次即可，badge 变化才重注册）。
@@ -2003,7 +2010,7 @@ export function apply(ctx: Context): void {
         }
         if (todoSuggestions !== todosBadgeCount) {
           todosBadgeCount = todoSuggestions
-          registerTodosTab()
+          todoTabLifecycle.refresh()
         }
       })
       .catch(() => { /* badge is best-effort; the tab still works */ })
@@ -2011,7 +2018,7 @@ export function apply(ctx: Context): void {
 
   void fetch('/memory-evolve/api/config')
     .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
-    .then((data: { config?: { memoryTabEnabled?: boolean; modelsEnabled?: boolean } }) => {
+    .then((data: { config?: { memoryTabEnabled?: boolean; modelsEnabled?: boolean; syncEnabled?: boolean; todoEnabled?: boolean } }) => {
       // 模型设置 tab：跟随 modelsEnabled 运行时开关（默认开，与其他模块
       // 同款独立开关，在「设置」Tab 的「配置」里切换；开启后刷新页面出现）。
       if (!tabCancelled && data.config?.modelsEnabled === true && disposeModelsTab === undefined) {
@@ -2029,7 +2036,7 @@ export function apply(ctx: Context): void {
       // 四个核心 tab 一起注册：记忆 / 技能 / 待办 / 设置（顺序 10/20/30/120）。
       registerMemoryTab()
       registerSkillsTab()
-      registerTodosTab()
+      todoTabLifecycle.setEnabled(data.config?.todoEnabled !== false)
       registerSettingsTab()
       pollBadge()
       const timer = setInterval(pollBadge, BADGE_POLL_MS)
@@ -2060,7 +2067,7 @@ export function apply(ctx: Context): void {
     tabCancelled = true
     disposeMemoryTab?.()
     disposeSkillsTab?.()
-    disposeTodosTab?.()
+    todoTabLifecycle.dispose()
     disposeSettingsTab?.()
   }, 'memory-evolve: memory tabs')
 

--- a/src/client/todo-tab-lifecycle.js
+++ b/src/client/todo-tab-lifecycle.js
@@ -1,0 +1,31 @@
+export const RUNTIME_CONFIG_CHANGED = 'dsh-memory-evolve:runtime-config-changed'
+
+/** Framework-free lifecycle for a conditional conversation tab. */
+export function createTodoTabLifecycle(register) {
+  let enabled = false
+  let disposer
+  const mount = () => {
+    disposer?.()
+    disposer = register()
+  }
+  return {
+    setEnabled(next) {
+      enabled = next === true
+      if (!enabled) {
+        disposer?.()
+        disposer = undefined
+      } else if (disposer === undefined) {
+        mount()
+      }
+    },
+    refresh() {
+      if (enabled && disposer !== undefined) mount()
+    },
+    dispose() {
+      enabled = false
+      disposer?.()
+      disposer = undefined
+    },
+    enabled: () => enabled,
+  }
+}

--- a/tests/todo-tab-lifecycle.test.js
+++ b/tests/todo-tab-lifecycle.test.js
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createTodoTabLifecycle } from '../src/client/todo-tab-lifecycle.js'
+
+test('todo tab lifecycle: disabled state disposes immediately and badge refresh cannot revive it', () => {
+  let registrations = 0
+  let disposals = 0
+  const lifecycle = createTodoTabLifecycle(() => {
+    registrations += 1
+    return () => { disposals += 1 }
+  })
+
+  lifecycle.setEnabled(true)
+  lifecycle.setEnabled(false)
+  lifecycle.setEnabled(false)
+  lifecycle.refresh()
+  assert.equal(registrations, 1)
+  assert.equal(disposals, 1)
+
+  lifecycle.setEnabled(true)
+  assert.equal(registrations, 2)
+  lifecycle.dispose()
+  assert.equal(disposals, 2)
+})

--- a/tests/todo.test.js
+++ b/tests/todo.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { TodoStore, TODO_HEADER, TODO_TARGETS, stampTodoLine, todoToolDefinition } from '../lib/todo.js'
 import { ArchiveStore, MemoryStore, SuggestionQueue, projectHash, todayStamp } from '../lib/store.js'
-import { approveSuggestions, archiveSuggestions, enqueueSuggestion, promoteArchived } from '../lib/review.js'
+import { approveSuggestions, archiveSuggestions, enqueueSuggestion, promoteArchived, suggestToolDefinition } from '../lib/review.js'
 import { installApi } from '../lib/api.js'
 
 function tempDir() {
@@ -566,7 +566,7 @@ test('todo suggestions: archive keeps origin track, promote writes it back', () 
 })
 
 /** Boot the real API handler with a todo store over a real HTTP server. */
-async function bootTodoApi() {
+async function bootTodoApi(runtime = {}) {
   const dir = tempDir()
   const todoStore = new TodoStore(dir)
   const archive = new ArchiveStore(dir)
@@ -582,7 +582,7 @@ async function bootTodoApi() {
   installApi(ctx, {
     store: { add: () => ({ ok: true, message: 'ok' }) },
     archive, queue, todoStore,
-    getRuntime: () => ({}),
+    getRuntime: () => runtime,
     updateRuntime: (patch) => patch,
     config: { memoryDir: dir, skillDir: join(dir, 'skills') },
     resolveCwd: (sessionId) => (sessionId === 's1' ? '/proj/api' : undefined),
@@ -640,4 +640,130 @@ test('todo API: list/add/done/update/remove over HTTP', async () => {
     await api.close()
     rmSync(api.dir, { recursive: true, force: true })
   }
+})
+
+test('todoEnabled: default is enabled and accepts only booleans', async () => {
+  const { DEFAULTS, RUNTIME_KEYS, resolveConfig, validateRuntimePatch } = await import('../lib/index.js')
+  assert.equal(DEFAULTS?.todoEnabled, true)
+  assert.ok(RUNTIME_KEYS?.includes('todoEnabled'))
+  assert.throws(() => resolveConfig({ todoEnabled: 'false' }), /todoEnabled 必须是布尔值/)
+  assert.doesNotThrow(() => validateRuntimePatch?.('todoEnabled', false))
+  assert.throws(() => validateRuntimePatch?.('todoEnabled', 'false'), /todoEnabled 必须是布尔值/)
+})
+
+test('dtodo: a stale tool refuses to write after todoEnabled switches off', async () => {
+  const dir = tempDir()
+  try {
+    const store = new TodoStore(dir)
+    const tool = todoToolDefinition({ todoToolName: 'dtodo' }, store, () => false)
+    const result = await tool.execute({ action: 'add', target: 'work', content: '不得写入' }, {})
+    assert.deepEqual(result, { ok: false, code: 'TODO_DISABLED', message: '待办功能未启用' })
+    assert.equal(store.itemsOf('work').length, 0)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('dtodo: output schema permits the disabled error code', () => {
+  const dir = tempDir()
+  try {
+    const tool = todoToolDefinition({ todoToolName: 'dtodo' }, new TodoStore(dir))
+    assert.equal(tool.output.schema.properties.code.type, 'string')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('todo controller: toggling registers, disposes, then restores dtodo', async () => {
+  const dir = tempDir()
+  try {
+    const { createTodoController } = await import('../lib/todo.js')
+    assert.equal(typeof createTodoController, 'function')
+    const registered = []
+    let disposals = 0
+    let runtime = {}
+    const ctx = {
+      tools: {
+        register(definition) {
+          registered.push(definition.name)
+          return () => { disposals += 1 }
+        },
+      },
+    }
+    const ctrl = createTodoController(ctx, { todoToolName: 'dtodo' }, () => runtime, new TodoStore(dir))
+    assert.deepEqual(registered, ['dtodo'])
+    runtime = { todoEnabled: false }
+    ctrl.sync()
+    ctrl.sync()
+    assert.equal(disposals, 1)
+    runtime = { todoEnabled: true }
+    ctrl.sync()
+    assert.deepEqual(registered, ['dtodo', 'dtodo'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('todo disabled: API rejects reads and writes without changing stored todos', async () => {
+  const api = await bootTodoApi({ todoEnabled: false })
+  try {
+    api.todoStore.addTodo('work', '既有待办', {}, undefined)
+    const before = readFileSync(join(api.dir, 'TODOS-work.md'), 'utf8')
+    const read = await api.request('GET', '/memory-evolve/api/todo')
+    const write = await api.request('POST', '/memory-evolve/api/todo', { action: 'add', target: 'work', content: '不得写入' })
+    const promote = await api.request('POST', '/memory-evolve/api/archive/promote', { target: 'todo-archive', match: '不得转正' })
+    assert.equal(read.status, 503)
+    assert.equal(write.status, 503)
+    assert.equal(promote.status, 503)
+    assert.equal(read.data.code, 'TODO_DISABLED')
+    assert.equal(write.data.code, 'TODO_DISABLED')
+    assert.equal(promote.data.code, 'TODO_DISABLED')
+    assert.equal(readFileSync(join(api.dir, 'TODOS-work.md'), 'utf8'), before)
+  } finally {
+    await api.close()
+    rmSync(api.dir, { recursive: true, force: true })
+  }
+})
+
+test('todo disabled: approval keeps todo suggestions while approving memory suggestions', () => {
+  const dir = tempDir()
+  try {
+    const store = new MemoryStore(dir)
+    const todoStore = new TodoStore(dir)
+    const queue = new SuggestionQueue(join(dir, 'SUGGESTIONS.jsonl'))
+    enqueueSuggestion(queue, 'memory', '可写入的记忆', 'r')
+    enqueueSuggestion(queue, 'todo-work', '不得写入的待办', 'r')
+    const report = approveSuggestions(store, todoStore, queue, [1, 2], undefined, undefined, undefined, { isTodoEnabled: () => false })
+    assert.equal(store.entriesOf('memory').length, 1)
+    assert.equal(todoStore.itemsOf('work').length, 0)
+    assert.equal(report.remaining, 1)
+    assert.match(report.lines[1], /TODO_DISABLED/)
+    assert.equal(queue.read()[0].target, 'todo-work')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('todo disabled: memory_suggest refuses new todo suggestions', async () => {
+  const dir = tempDir()
+  try {
+    const queue = new SuggestionQueue(join(dir, 'SUGGESTIONS.jsonl'))
+    const tool = suggestToolDefinition({ suggestToolName: 'memory_suggest' }, queue, () => false)
+    const result = await tool.execute({ target: 'todo-work', content: '不得入队', reason: 'r' }, {})
+    assert.deepEqual(result, { ok: false, code: 'TODO_DISABLED', message: '待办功能未启用' })
+    assert.equal(queue.read().length, 0)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('todo disabled: snapshot omits dtodo guidance', async () => {
+  const { renderSnapshot } = await import('../lib/index.js')
+  const store = { entriesOf: () => [] }
+  const disabled = renderSnapshot({ todoEnabled: false }, store, undefined, undefined)
+  const enabled = renderSnapshot({ todoEnabled: true }, store, undefined, undefined)
+  assert.ok(!disabled.includes('dtodo'))
+  assert.ok(enabled.includes('dtodo'))
+  assert.ok(enabled.includes('\n- 待办（dtodo）：'))
+  assert.ok(!enabled.includes('\n\n待办（dtodo）：'))
 })


### PR DESCRIPTION
### 功能概述

新增 `todoEnabled` 运行时配置开关，允许用户完全禁用待办功能模块。这是一个独立子模块开关，默认启用（`true`），与现有的 `bookmarkEnabled`、`notifyEnabled` 等开关保持一致的设计模式。

### 实现细节

**后端改动：**
- 新增 `todoEnabled` 配置项（默认 `true`），加入 `RUNTIME_KEYS` 和 `BOOLEAN_KEYS` 验证
- 实现 `createTodoController` 生命周期管理器，动态注册/卸载 `dtodo` 工具
- 所有待办 API 端点（`/api/todo`、`/api/archive/promote`）添加禁用守卫，返回 `503 TODO_DISABLED`
- `memory_suggest` 工具拒绝 `todo-*` 目标时返回明确错误码
- `approveSuggestions` 跳过待办建议但继续处理记忆建议
- 系统提示词渲染时根据开关状态决定是否包含 dtodo 指导

**前端改动：**
- 配置面板新增「待办功能」开关（含中英文说明）
- 实现 `createTodoTabLifecycle` 管理待办 Tab 的挂载/卸载
- 保存配置后通过 `RUNTIME_CONFIG_CHANGED` 事件通知 Tab 生命周期
- 禁用时立即隐藏待办 Tab，启用时恢复显示

**数据保护：**
- 禁用操作完全可逆，不删除任何待办数据文件
- 同步轨（sync track）保持独立，不受影响
- 重新启用后功能立即恢复，无需额外操作

### 使用场景

- 用户不需要待办功能时，可完全关闭以减少界面干扰
- 临时禁用待办写入（如专注模式），同时保留现有数据
- 排查待办相关问题时快速隔离模块

### 测试覆盖

新增 12 个测试用例，共 28 个待办相关测试全部通过：
- 配置验证：默认值、类型检查、运行时补丁
- 工具禁用：过期工具调用拒绝写入
- 控制器生命周期：注册、卸载、恢复
- API 守卫：读写拒绝、数据不变
- 审批流程：混合建议处理
- 系统提示词：条件渲染

### 向后兼容性

- 默认值 `true` 保持现有行为不变
- 旧配置文件缺少 `todoEnabled` 时自动启用
- 所有 API 错误响应包含 `code: 'TODO_DISABLED'` 便于程序判断