### PR TITLE
fix(search): 修复全盘 dir 搜索卡死——WALK_IGNORE 补系统目录 + maxFiles 截断后清空队列 + defaultRoots 去重

### DIFF
--- a/lib/search-docs.js
+++ b/lib/search-docs.js
@@ -150,21 +150,37 @@ export function matchQuery(name, query) {
   return name.toLowerCase().includes(query.toLowerCase())
 }
 
-/** 默认搜索根：用户主目录 + 平台外置卷/其它盘符。 */
+/** 默认搜索根：用户主目录 + 平台外置卷/其它盘符。
+ *  Windows 去重：homedir（C:\Users\xxx）是 C:\ 子集，同时扫描两者会重复遍历
+ *  整个 C 盘（2026-08-26 修复：全盘 dir 搜索卡死根因之一）。 */
 export function defaultRoots(platform = process.platform) {
   const home = homedir()
-  const roots = [home]
+  const roots = []
+  const homeRoot = home.slice(0, 3).toLowerCase() // 'c:\'
   try {
     if (platform === 'darwin') {
+      roots.push(home)
       for (const name of readdirSync('/Volumes')) {
         if (!name.startsWith('.')) roots.push(join('/Volumes', name))
       }
     } else if (platform === 'win32') {
+      // 先加非 homedir 所在盘，再加 homedir 盘（避免重复扫描）
+      const drives = []
       for (let c = 65; c <= 90; c++) {
         const drive = `${String.fromCharCode(c)}:\\`
-        if (existsSync(drive)) roots.push(drive)
+        if (existsSync(drive)) drives.push(drive)
+      }
+      // homedir 所在盘 → 只加 homedir（不扫 C:\Windows 等）
+      // 其它盘 → 加盘符根（外置盘通常无系统目录）
+      for (const drive of drives) {
+        if (drive.toLowerCase() === homeRoot) {
+          roots.push(home)
+        } else {
+          roots.push(drive)
+        }
       }
     } else {
+      roots.push(home)
       for (const p of ['/home', '/media', '/mnt']) {
         if (existsSync(p)) roots.push(p)
       }
@@ -343,12 +359,21 @@ registerSearchProvider('rg', (config) => ({
 // 内置 provider：walk（Node 并发遍历 + 结果缓存，零依赖兜底）
 // ---------------------------------------------------------------------------
 
-/** walk 忽略的目录名（大小写不敏感比较）。 */
+/** walk 忽略的目录名（大小写不敏感比较）。
+ *  补充 Windows 系统目录（2026-08-26 修复：全盘 dir 搜索卡死 19 分钟根因）。 */
 const WALK_IGNORE = new Set([
   'node_modules', '.git', 'library', 'appdata', 'system32', '.cache',
   '.trash', '.trashes', '.spotlight-v100', '.fseventsd',
   '.documentrevisions-v100', '.temporaryitems', '__pycache__',
   'venv', '.venv', '.tox', '.pytest_cache', 'site-packages',
+  // — Windows 系统目录（13 万+子目录，遍历耗时分钟级）—
+  'windows', 'program files', 'program files (x86)', 'programdata',
+  '$recycle.bin', 'system volume information', 'drivers',
+  'windowsapps', 'wpsystem', 'recovery',
+  // — macOS 系统目录 —
+  'system', 'library', 'private',
+  // — Linux 系统目录 —
+  'proc', 'sys', 'dev', 'run', 'snap',
 ])
 
 /** walk 缓存里收录的文档扩展名集合（查询时按请求 exts 过滤）。 */
@@ -395,6 +420,13 @@ async function walkFiles(root, { extSet, signal, concurrency = 16, maxFiles = 50
               const ext = extname(name).slice(1).toLowerCase()
               if (kind === 'any' || extSet.has(ext)) found.push(join(dir, name))
             }
+          }
+          // maxFiles 截断后清空队列，防大量 pending readdir 继续占住事件循环
+          // （2026-08-26 修复：全盘 dir 搜索卡死 19 分钟根因——maxFiles 只停
+          // 止新增 while 循环，但 queue 中已有目录的 readdir promise 仍会
+          // resolve 并 startNext，形成数千个微任务级联，IO 总量等同全盘遍历）
+          if (found.length >= maxFiles) {
+            queue.length = 0
           }
           startNext()
           maybeFinish(resolveWalk)
@@ -476,7 +508,9 @@ function createWalkProvider(config) {
         const roots = dir ? [dir] : defaultRoots().filter((root) => existsSync(root))
         const all = []
         for (const root of roots) {
-          const paths = await walkFiles(root, { extSet, signal, maxFiles: kind === 'dir' ? 20000 : 50000, kind })
+          // dir 类型预算从 20000 降到 10000：系统目录已 IGNORE，
+          // 10000 足够覆盖正常用户数据目录树。
+          const paths = await walkFiles(root, { extSet, signal, maxFiles: kind === 'dir' ? 10000 : 50000, kind })
           all.push(...paths)
         }
         return finalize(all, { query, exts, limit, kind })


### PR DESCRIPTION
## 问题

记忆插件更新后，使用 memory_evolve_search_local_files 工具执行全盘目录搜索（llTypes: true + 	ype: "dir"）时卡死，实测 19 分钟未返回，无法停止对话只能重启 DSH。

## 根因（三处）

### 1. WALK_IGNORE 缺 Windows 系统目录
WALK_IGNORE 集合只忽略了 
ode_modules、.git 等开发目录，但**没有忽略 Windows、Program Files、ProgramData 等 Windows 系统目录**。本机实测 C:\Windows 有 **131,577 个子目录**，遍历耗时分钟级。

### 2. defaultRoots 导致 C 盘扫描两遍
Windows 下 defaultRoots() 同时将 homedir（C:\Users\xxx）和盘符根 C:\ 加入 roots 数组。由于 homedir 是 C:\ 的子集，**C 盘被扫描两遍**。

### 3. walkFiles maxFiles 截断未清空队列（核心 bug）
walkFiles 的 maxFiles 截断只停止 while 循环新增任务，但 **queue 中已有目录的 eaddir promise 仍会 resolve 并调用 startNext()**，形成数千个微任务级联。即使 ound.length >= maxFiles，pending 的 IO 操作总量等同于全盘遍历，事件循环被占满。

## 修复（三处，共 +39 -5 行）

1. **WALK_IGNORE 补充系统目录**：Windows（windows、program files、programdata、$recycle.bin 等）、macOS（system、private）、Linux（proc、sys、dev 等）
2. **defaultRoots Windows 去重**：homedir 所在盘只加 homedir，不加盘符根
3. **walkFiles maxFiles 截断后 queue.length = 0**：清空待处理队列，终止 pending readdir 的级联
4. dir 类型 maxFiles 从 20000 降到 10000（系统目录已忽略，10000 足够覆盖用户数据）

## 实测

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| llTypes: true, type: "dir", query: "xianyu" | **19 分钟卡死** | **316ms** |
| 搜索 "dsh" 目录 | 同样卡死 | 316ms，13 个结果 |

测试环境：Windows 11，3 个盘符（C/D/E），C:\Windows 131K 子目录。