### PR TITLE
fix(headless): make workspace registry optional

### DIFF
--- a/lib/bookmarks.js
+++ b/lib/bookmarks.js
@@ -381,7 +381,7 @@ export function buildForkSeed(events, atSeq) {
  * workspace.attachSession 挂到左侧列表（源会话的 cwd 工作区）。不修改源
  * 会话任何数据；子会话通过 meta.parentSession 进入官方谱系树。
  *
- * @param {object} ctx - 插件 cordis ctx（agents/workspace 已声明式注入）。
+ * @param {object} ctx - 插件 cordis ctx（agents 已声明式注入；workspace 可选）。
  * @param {string} sessionId - 源会话 id。
  * @param {number | undefined} atSeq - 目标轮内消息 seq（省略=最后一轮）。
  * @returns {Promise<{ sessionId: string, parentSession: string, cwd: string | null }>}
@@ -413,9 +413,12 @@ export async function forkSession(ctx, sessionId, atSeq) {
     },
   })
   // 挂到工作区（与官方 fork 同款；attach 失败只影响左侧分组，不阻断）。
-  if (typeof cwd === 'string' && ctx.workspaceRegistry) {
+  const workspaceRegistry = typeof ctx.get === 'function'
+    ? ctx.get('workspaceRegistry')
+    : ctx.workspaceRegistry
+  if (typeof cwd === 'string' && workspaceRegistry) {
     try {
-      const ws = await ctx.workspaceRegistry.resolveByPath(cwd)
+      const ws = await workspaceRegistry.resolveByPath(cwd)
       if (ws !== undefined) await ws.attachSession(childId)
     } catch (error) {
       console.warn(`[dsh-memory-evolve] 分支会话 ${childId} 挂接工作区失败（忽略）: ${String(error)}`)

--- a/lib/coi/ws-coord.js
+++ b/lib/coi/ws-coord.js
@@ -841,7 +841,10 @@ export function installWsCoord(ctx, config, deps = {}) {
    */
   const archivedIds = () => {
     try {
-      const list = ctx.workspaceRegistry?.archivedSessionIds
+      const workspaceRegistry = typeof ctx.get === 'function'
+        ? ctx.get('workspaceRegistry')
+        : ctx.workspaceRegistry
+      const list = workspaceRegistry?.archivedSessionIds
       if (!Array.isArray(list) || list.length === 0) return null
       return new Set(list)
     } catch { return null }

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,8 +60,9 @@ export const name = 'dsh-memory-evolve'
 // tools/systemPrompt 是历史声明；agents 于 2026-08-09 加入——会话编排
 // 模块（de_session）需要它创建/唤醒会话（曾用 ctx.inject(['agents'])
 // 动态注入导致工具未注册，改为声明式注入后与 tools 同款可靠）；
-// workspace 同批加入——spawn 需要把新会话 attach 到工作区（左侧会话
-// 列表的"项目"分组，否则新会话落在「未分组」）；
+// workspaceRegistry 刻意不做插件级硬依赖：headless bundle 不提供该
+// web-only 服务，而默认的记忆工具与提示词注入并不需要它。需要工作区的
+// 可选能力通过 ctx.get() / 局部 ctx.inject() 读取并明确降级。
 // sessionTitle 同日加入——de_session rename 改会话名称（左侧列表标题）。
 // sessionPersistence 于 2026-08-11 加入——de_session wake 恢复离线会话时
 // 需读该会话 log 里自己最后使用的模型（request/header），否则恢复的
@@ -69,7 +70,7 @@ export const name = 'dsh-memory-evolve'
 // settings / llm 于 2026-08-11 加入——模型配置模块（de_models 工具 +
 // 「模型设置」Tab）需要读取模型目录（settings.get）与供应商/思考等级
 // 元数据（llm.listConfigurableProviders / resolveModelInfo）。
-export const inject = ['tools', 'systemPrompt', 'agents', 'workspaceRegistry', 'sessionTitle', 'sessionPersistence', 'settings', 'llm']
+export const inject = ['tools', 'systemPrompt', 'agents', 'sessionTitle', 'sessionPersistence', 'settings', 'llm']
 
 /** Plugin config defaults (conservative: review off, memory on). */
 export const DEFAULTS = {

--- a/lib/session-orch.js
+++ b/lib/session-orch.js
@@ -191,7 +191,6 @@ export class SessionOrch {
   constructor(ctx, deps) {
     this.ctx = ctx
     this.agents = ctx.agents
-    this.workspace = ctx.workspaceRegistry // 工作区注册表（左侧会话列表"项目"分组依据）
     this.sessionTitle = ctx.sessionTitle // 会话名称服务（rename 改左侧列表标题）
     this.sessionPersistence = ctx.sessionPersistence // 会话持久化（wake offline 读自身模型配置）
     // ⚠️ 模型目录解析（2026-08-11 踩坑）：llm/settings 是主插件声明式注入的
@@ -221,6 +220,17 @@ export class SessionOrch {
       : null
     /** 本模块 spawn 出的 live AgentHandle（模块卸载时清理，防泄漏）。 */
     this.spawnedHandles = new Map()
+  }
+
+  /**
+   * Resolve the optional workspace service at use time. Headless never
+   * provides it, while a web host may publish it after this plugin starts.
+   * The property fallback supports the repository's plain-object test rigs.
+   */
+  get workspace() {
+    return typeof this.ctx.get === 'function'
+      ? this.ctx.get('workspaceRegistry')
+      : this.ctx.workspaceRegistry
   }
 
   /**
@@ -414,12 +424,21 @@ export class SessionOrch {
       if (i > 0 && this.attachDelays[i] > 0) {
         await new Promise((resolve) => setTimeout(resolve, this.attachDelays[i]))
       }
+      // Keep one service generation for the whole attempt. A web runtime can
+      // replace/unload the optional provider while resolveByPath awaits; the
+      // next retry may observe the new generation, but this attempt must not
+      // mix methods from two providers.
+      const workspace = this.workspace
+      if (!workspace) {
+        lastErr = 'workspace 服务不可用'
+        continue
+      }
       try {
-        ws = await this.workspace.resolveByPath(cwd)
+        ws = await workspace.resolveByPath(cwd)
         if (ws === undefined) {
           // workspace 记录不存在（显式 cwd 的新目录等）：create 兜底
           // （与 GUI 创建会话同款：先建工作区再 attach）
-          ws = await this.workspace.create(cwd)
+          ws = await workspace.create(cwd)
         }
         await ws.attachSession(sessionId)
         return {
@@ -1305,7 +1324,8 @@ export function installSession(ctx, config, deps) {
   /** 当前编排器实例（卸载时置 null）。 */
   let orch = null
   try {
-    // agents/workspace/sessionTitle 已声明式注入，直接可用（同 tools）
+    // agents/sessionTitle 已声明式注入；workspaceRegistry 按需读取，
+    // headless 缺失时 spawn 仍成功，只跳过左侧工作区挂接。
     const instance = new SessionOrch(ctx, {
       store,
       getBroadcastStore: deps?.getBroadcastStore,

--- a/tests/bookmarks.test.js
+++ b/tests/bookmarks.test.js
@@ -425,6 +425,32 @@ test('forkSession: agents.create 收到 seed/meta，workspace attach 被调用',
   assert.equal(attached, result.sessionId)
 })
 
+test('forkSession: headless skips workspace attach and observes a later web service', async () => {
+  const events = makeEvents()
+  let published
+  let attached = null
+  const workspaceRegistry = {
+    resolveByPath: async () => ({
+      id: 'ws-late',
+      attachSession: async (sid) => { attached = sid },
+    }),
+  }
+  const ctx = {
+    agents: {
+      get: () => ({ session: { events, header: { cwd: '/tmp/proj' } } }),
+      create: async () => {},
+    },
+    get: (name) => (name === 'workspaceRegistry' ? published : undefined),
+  }
+
+  await forkSession(ctx, 'session-src', 2)
+  assert.equal(attached, null, 'headless must still fork without a workspace service')
+
+  published = workspaceRegistry
+  const result = await forkSession(ctx, 'session-src', 2)
+  assert.equal(attached, result.sessionId, 'a later web-host service is resolved at use time')
+})
+
 test('forkSession: 会话不存在 / 目标轮未完成 → 抛业务错误', async () => {
   const events = makeEvents()
   events.push({ seq: events.length, type: 'turn/start', turn: 3 })

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { spawnSync } from 'node:child_process'
-import { apply, gitBranch, gitBranchList, resolveConfig, renderSnapshot, resolveRevealTarget, toWindowsPath } from '../lib/index.js'
+import { apply, gitBranch, gitBranchList, inject, resolveConfig, renderSnapshot, resolveRevealTarget, toWindowsPath } from '../lib/index.js'
 import { setLocale } from '../lib/i18n.js'
 import { installCanvas } from '../lib/canvas.js'
 
@@ -220,6 +220,19 @@ test('apply registers memory tool and snapshot context by default', () => {
   assert.ok(!ctx.state.tools.some((t) => t.name === 'memory_suggest'), 'suggest tool off by default')
   assert.ok(ctx.state.commands.some((c) => c.name === 'memory_review'), 'review command registered')
   clean(dir)
+})
+
+test('headless host activation does not require the web-only workspaceRegistry service', () => {
+  assert.equal(inject.includes('workspaceRegistry'), false)
+  const dir = tempDir()
+  try {
+    const ctx = fakeCtx()
+    apply(ctx, { memoryDir: dir })
+    assert.ok(ctx.state.tools.some((tool) => tool.name === 'memory'))
+    assert.ok(ctx.state.contexts.some((context) => context.name === 'memory:snapshot'))
+  } finally {
+    clean(dir)
+  }
 })
 
 test('search docs tool: 默认禁用不注册；配置/运行时 state 开启后注册；命令始终注册', () => {

--- a/tests/session-orch.test.js
+++ b/tests/session-orch.test.js
@@ -168,6 +168,54 @@ test('SessionOrchStore: spawn 记录落盘/查找/列表', () => {
   rmSync(dir, { recursive: true, force: true })
 })
 
+test('SessionOrch resolves an optional workspace service lazily', () => {
+  const dir = tempDir()
+  const ctx = makeCtx(makeFakeAgents())
+  const workspace = ctx.workspaceRegistry
+  let published
+  ctx.get = (name) => (name === 'workspaceRegistry' ? published : undefined)
+  const orch = new SessionOrch(ctx, {
+    store: new SessionOrchStore(dir),
+    getBroadcastStore: () => undefined,
+  })
+
+  assert.equal(orch.workspace, undefined, 'headless starts without workspaceRegistry')
+  published = workspace
+  assert.equal(orch.workspace, workspace, 'a later web-host service is observed on demand')
+  rmSync(dir, { recursive: true, force: true })
+})
+
+test('attachWorkspace keeps one optional-service generation per attempt', async () => {
+  const dir = tempDir()
+  const ctx = makeCtx(makeFakeAgents())
+  let published
+  let created = 0
+  let attached = null
+  const firstGeneration = {
+    resolveByPath: async () => {
+      published = undefined
+      return undefined
+    },
+    create: async () => {
+      created += 1
+      return { id: 'ws-stable', title: 'stable', attachSession: async (sid) => { attached = sid } }
+    },
+  }
+  published = firstGeneration
+  ctx.get = (name) => (name === 'workspaceRegistry' ? published : undefined)
+  const orch = new SessionOrch(ctx, {
+    store: new SessionOrchStore(dir),
+    getBroadcastStore: () => undefined,
+    attachDelays: [0],
+  })
+
+  const result = await orch.attachWorkspace('session-child', dir)
+  assert.equal(result.ok, true)
+  assert.equal(created, 1, 'create must use the same provider captured before resolveByPath')
+  assert.equal(attached, 'session-child')
+  rmSync(dir, { recursive: true, force: true })
+})
+
 test('de_session schema: Code Mode 安全——模型可见文本不含 {{ 模板语法', () => {
   const dir = tempDir()
   const ctx = makeCtx(makeFakeAgents())

--- a/tests/ws-coord.test.js
+++ b/tests/ws-coord.test.js
@@ -521,13 +521,18 @@ test('buildWsCoordBlock：observed 锁 30s 过期/重登记不改变文本（not
 function makeWsCtx(agentsMap) {
   const listeners = {}
   const registered = []
+  const workspaceRegistry = { archivedSessionIds: [] }
   const ctx = {
     listeners,
-    get: (name) => (name === 'agents' ? { get: (sid) => agentsMap.get(sid) ?? null } : undefined),
+    get: (name) => {
+      if (name === 'agents') return { get: (sid) => agentsMap.get(sid) ?? null }
+      if (name === 'workspaceRegistry') return workspaceRegistry
+      return undefined
+    },
     on: (event, fn) => { (listeners[event] ??= []).push(fn); return () => {} },
     effect: (fn) => { const out = fn(); return typeof out === 'function' ? out : () => {} },
     tools: { register: () => () => {} },
-    workspaceRegistry: { archivedSessionIds: [] },
+    workspaceRegistry,
   }
   return ctx
 }


### PR DESCRIPTION
## Summary

- remove the web-only `workspaceRegistry` service from the plugin's hard injection list
- resolve that optional service only when workspace-aware features need it
- preserve headless memory/prompt activation while letting session creation and forks skip only workspace grouping
- keep a single workspace service generation for each attach attempt

## Verification

- exact DSH `0.1.2-alpha.2` Cordis runtime: current main remains `PENDING` without `workspaceRegistry`; this patch reaches `ACTIVE`
- focused affected suites: 82/82 passed on Linux
- full Linux suite: 732/780 passed; every failure on the patched run reproduces on exact parent `1e6e7eb`
- build and diff checks passed
- independent exact-diff review: no P0-P3 findings

Closes #35