### PR TITLE
fix(review): adapt to Session ownEvents() on dsh 0.1.2-alpha.4+

### DIFF
--- a/lib/review.js
+++ b/lib/review.js
@@ -77,7 +77,13 @@ export function reviewTurnCounter(ctx, getRuntime) {
       // inbox.nextStep.length === 0 时发出，next-step 注入回合已被排除，
       // 到达这里的都是用户消息回合；DSH 未来若补上 trigger 字段则自动
       // 恢复正常判定。
-      const events = agent.session.events
+      // ⚠ 修复（2026-09-02，DSH 0.1.2-alpha.4 适配）：Session 类不再暴露
+      // `.events` 数组（读它会得到 undefined，`events.length` 抛 TypeError:
+      // Cannot read properties of undefined (reading 'length')，回合结束时
+      // 冒泡为「turn-stopping 处理失败」），改为 `ownEvents()` / 兼容字段。
+      // `ownEvents()` 返回不含 fork 前缀的子会话事件（log 序），从尾部回扫
+      // turn/start 语义不变；老宿主（<= 0.1.1-rc）仍走 `.events`。
+      const events = agent.session.ownEvents?.() ?? agent.session.events ?? []
       let messageTurn = false
       for (let index = events.length - 1; index >= 0; index -= 1) {
         const event = events[index]

--- a/tests/review-alpha-session.test.js
+++ b/tests/review-alpha-session.test.js
@@ -1,0 +1,84 @@
+/**
+ * 回归测试：DSH 0.1.2-alpha.4+ 的 Session 形状（ownEvents() 取代 .events）。
+ * 旧代码读 `agent.session.events.length`，新宿主下 events 为 undefined 会抛
+ * TypeError（Cannot read properties of undefined (reading 'length')），
+ * turn-stopping 回调被打成「处理失败」、审查计数永不累加。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { reviewTurnCounter } from '../lib/review.js'
+
+/**
+ * 最小 Cordis 上下文桩：只实现 on/effect，够 reviewTurnCounter 注册监听。
+ * @returns {{state: {listeners: Record<string, Function[]>}, ctx: object}}
+ */
+function fakeCtx() {
+  const state = { listeners: {} }
+  const ctx = {
+    on(name, listener) {
+      ;(state.listeners[name] ??= []).push(listener)
+      return () => { state.listeners[name] = state.listeners[name].filter((l) => l !== listener) }
+    },
+    effect(setup) { const dispose = setup(); return typeof dispose === 'function' ? dispose : () => {} },
+  }
+  return { state, ctx }
+}
+
+/**
+ * 构造一个回合的用户事件序列（log 序、带连续 seq）。
+ * @param {number[]} turns - 回合编号列表。
+ * @returns {object[]} 事件数组。
+ */
+function turnEvents(turns) {
+  return turns.flatMap((turn) => [
+    { type: 'turn/start', data: { turn } },
+    { type: 'user/message', data: { id: `u${turn}`, role: 'user', source: { kind: 'user' }, content: [{ type: 'text', text: `问题${turn}` }] } },
+  ]).map((event, seq) => ({ ...event, seq }))
+}
+
+test('alpha session shape: ownEvents() replaces .events and the counter still works', () => {
+  const { state, ctx } = fakeCtx()
+  const counter = reviewTurnCounter(ctx, () => ({ reviewEnabled: true }))
+  const listener = state.listeners['agent/turn-stopping'][0]
+  assert.ok(listener, 'turn-stopping listener registered')
+
+  // Alpha.4+ Session：没有 .events 字段，只有 ownEvents()（fork 后自有事件，log 序）。
+  const alphaAgent = (id, turns) => ({
+    id,
+    session: { header: { origin: undefined }, ownEvents: () => turnEvents(turns) },
+  })
+
+  // 不得抛错（回归点：events.length 读 undefined）。
+  assert.doesNotThrow(() => listener({ agent: alphaAgent('s1', [1]), turn: 1 }))
+  assert.equal(counter.turnsOf({ id: 's1' }), 1)
+
+  listener({ agent: alphaAgent('s1', [1, 2]), turn: 2 })
+  assert.equal(counter.turnsOf({ id: 's1' }), 2)
+
+  counter.complete({ id: 's1' })
+  assert.equal(counter.turnsOf({ id: 's1' }), 0)
+})
+
+test('legacy session shape: .events still works and stays preferred when ownEvents is absent', () => {
+  const { state, ctx } = fakeCtx()
+  const counter = reviewTurnCounter(ctx, () => ({ reviewEnabled: true }))
+  const listener = state.listeners['agent/turn-stopping'][0]
+
+  const legacyAgent = (id, turns) => ({
+    id,
+    session: { header: { origin: undefined }, events: turnEvents(turns) },
+  })
+
+  assert.doesNotThrow(() => listener({ agent: legacyAgent('s2', [1]), turn: 1 }))
+  assert.equal(counter.turnsOf({ id: 's2' }), 1)
+})
+
+test('defensive: session with neither accessor counts nothing instead of throwing', () => {
+  const { state, ctx } = fakeCtx()
+  const counter = reviewTurnCounter(ctx, () => ({ reviewEnabled: true }))
+  const listener = state.listeners['agent/turn-stopping'][0]
+
+  const bareAgent = { id: 's3', session: { header: { origin: undefined } } }
+  assert.doesNotThrow(() => listener({ agent: bareAgent, turn: 1 }))
+  assert.equal(counter.turnsOf({ id: 's3' }), 0)
+})


### PR DESCRIPTION
## 问题

DSH 升级到 0.1.2-alpha.4 后，每回合结束都报：

```
[memory-evolve review] turn-stopping 处理失败（已隔离，不影响回合）：
TypeError: Cannot read properties of undefined (reading 'length')
    at Object.onSettled (lib/review.js:82:31)
```

## 根因

alpha.4 的 `Session` 类**移除了 `.events` 数组**，事件改经 `ownEvents()` / `snapshotEvents()` / `.seq` 访问。`review.js` 里 `agent.session.events` 读到 undefined，`events.length` 抛 TypeError——审查计数器永不累加，全局记忆轨的到期审查实际瘫痪（只是错误被隔离没带崩回合）。

## 修复

```js
// 旧：const events = agent.session.events
const events = agent.session.ownEvents?.() ?? agent.session.events ?? []
```

- `ownEvents()`：新宿主访问器（fork 自有事件、log 序），尾部回扫 `turn/start` 语义不变；
- `.events`：老宿主（≤0.1.1-rc）兼容；
- 两者皆无（异常形状）→ 计 0 回合不抛错，与回调既有的隔离防护一致。

## 测试

新增 `tests/review-alpha-session.test.js` 三个回归：alpha 形状（仅 `ownEvents()`）计数正常、legacy 形状（仅 `.events`）不受影响、无访问器不抛错。本地 3/3 + review 相关 30/30 通过。

已在 0.1.2-alpha.4 真机热重载验证（fiber active，计数恢复累加）。
